### PR TITLE
Data structure for wiring between layers of boxes

### DIFF
--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -3,7 +3,7 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   MonoidalCategoryWithDiagonals, CartesianCategory, FreeCartesianCategory,
   mcopy, delete, pair, proj1, proj2, Δ, ◇,
   MonoidalCategoryWithCodiagonals, CocartesianCategory, FreeCocartesianCategory,
-  mmerge, create, copair, in1, in2, ∇, □,
+  mmerge, create, copair, incl1, incl2, ∇, □,
   BiproductCategory, FreeBiproductCategory,
   CartesianClosedCategory, FreeCartesianClosedCategory, hom, ev, curry,
   CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit,
@@ -176,8 +176,8 @@ qualifiers for brevity.
 """
 @signature MonoidalCategoryWithCodiagonals(Ob,Hom) => CocartesianCategory(Ob,Hom) begin
   copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) <= (A::Ob, B::Ob, C::Ob)
-  in1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
-  in2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
+  incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
+  incl2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
 end
 
 """ Syntax for a free cocartesian category.
@@ -192,8 +192,8 @@ Of course, this convention could be reversed.
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
   
   copair(f::Hom, g::Hom) = compose(otimes(f,g), mmerge(codom(f)))
-  in1(A::Ob, B::Ob) = otimes(id(A), create(B))
-  in2(A::Ob, B::Ob) = otimes(create(A), id(B))
+  incl1(A::Ob, B::Ob) = otimes(id(A), create(B))
+  incl2(A::Ob, B::Ob) = otimes(create(A), id(B))
 end
 
 function show_latex(io::IO, expr::HomExpr{:mmerge}; kw...)

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -1,8 +1,8 @@
 export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   SymmetricMonoidalCategory, FreeSymmetricMonoidalCategory, braid,
-  CartesianCategory, FreeCartesianCategory,
+  MonoidalCategoryWithDiagonals, CartesianCategory, FreeCartesianCategory,
   mcopy, delete, pair, proj1, proj2, Δ, ◇,
-  CocartesianCategory, FreeCocartesianCategory,
+  MonoidalCategoryWithCodiagonals, CocartesianCategory, FreeCocartesianCategory,
   mmerge, create, copair, in1, in2, ∇, □,
   BiproductCategory, FreeBiproductCategory,
   CartesianClosedCategory, FreeCartesianClosedCategory, hom, ev, curry,
@@ -91,25 +91,39 @@ function show_latex(io::IO, expr::HomExpr{:braid}; kw...)
   Syntax.show_latex_script(io, expr, "\\sigma")
 end
 
-# (Co)cartesian category
-########################
+# Cartesian category
+####################
+
+""" Doctrine of *monoidal category with diagonals*
+
+A monoidal category with diagonals is a symmetric monoidal category equipped
+with coherent collections of copying and deleting morphisms (comonoids).
+Unlike in a cartesian category, the naturality axioms need not be satisfied.
+
+References:
+
+- Selinger, 2010, "A survey of graphical languages for monoidal categories",
+  Section 6.6: "Cartesian center"
+- Selinger, 1999, "Categorical structure of asynchrony"
+"""
+@signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithDiagonals(Ob,Hom) begin
+  mcopy(A::Ob)::Hom(A,otimes(A,A))
+  delete(A::Ob)::Hom(A,munit())
+  
+  # Unicode syntax
+  Δ(A::Ob) = mcopy(A)
+  ◇(A::Ob) = delete(A)
+end
 
 """ Doctrine of *cartesian category*
 
 Actually, this is a cartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
-@signature SymmetricMonoidalCategory(Ob,Hom) => CartesianCategory(Ob,Hom) begin
-  mcopy(A::Ob)::Hom(A,otimes(A,A))
-  delete(A::Ob)::Hom(A,munit())
-  
+@signature MonoidalCategoryWithDiagonals(Ob,Hom) => CartesianCategory(Ob,Hom) begin
   pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) <= (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
-  
-  # Unicode syntax
-  Δ(A::Ob) = mcopy(A)
-  ◇(A::Ob) = delete(A)
 end
 
 """ Syntax for a free cartesian category.
@@ -135,22 +149,35 @@ function show_latex(io::IO, expr::HomExpr{:delete}; kw...)
   Syntax.show_latex_script(io, expr, "\\lozenge")
 end
 
+# Cocartesian category
+######################
+
+""" Doctrine of *monoidal category with codiagonals*
+
+A monoidal category with codiagonals is a symmetric monoidal category equipped
+with coherent collections of merging and creating morphisms (monoids).
+Unlike in a cocartesian category, the naturality axioms need not be satisfied.
+
+For references, see `MonoidalCategoryWithDiagonals`.
+"""
+@signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithCodiagonals(Ob,Hom) begin
+  mmerge(A::Ob)::Hom(otimes(A,A),A)
+  create(A::Ob)::Hom(munit(),A)
+
+  # Unicode syntax
+  ∇(A::Ob) = mmerge(A)
+  □(A::Ob) = create(A)
+end
+
 """ Doctrine of *cocartesian category*
 
 Actually, this is a cocartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
-@signature SymmetricMonoidalCategory(Ob,Hom) => CocartesianCategory(Ob,Hom) begin
-  mmerge(A::Ob)::Hom(otimes(A,A),A)
-  create(A::Ob)::Hom(munit(),A)
-  
+@signature MonoidalCategoryWithCodiagonals(Ob,Hom) => CocartesianCategory(Ob,Hom) begin
   copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) <= (A::Ob, B::Ob, C::Ob)
   in1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
   in2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
-  
-  # Unicode syntax
-  ∇(A::Ob) = mmerge(A)
-  □(A::Ob) = create(A)
 end
 
 """ Syntax for a free cocartesian category.

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -4,7 +4,7 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   mcopy, delete, pair, proj1, proj2, Δ, ◇,
   MonoidalCategoryWithCodiagonals, CocartesianCategory, FreeCocartesianCategory,
   mmerge, create, copair, incl1, incl2, ∇, □,
-  BiproductCategory, FreeBiproductCategory,
+  MonoidalCategoryWithBidiagonals, BiproductCategory, FreeBiproductCategory,
   CartesianClosedCategory, FreeCartesianClosedCategory, hom, ev, curry,
   CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit,
   DaggerCategory, FreeDaggerCategory, dagger,
@@ -206,14 +206,16 @@ end
 # Biproduct category
 ####################
 
-""" Doctrine of *bicategory category*
+""" Doctrine of *monoidal category with bidiagonals*
 
-Also known as a *semiadditive category*.
+The terminology is nonstandard (is there any standard terminology?) but is
+intended to mean a monoidal category with coherent diagonals and codiagonals.
+Unlike in a biproduct category, the naturality axioms need not be satisfied.
 
-FIXME: This signature should extend both `CartesianCategory` and
-`CocartesianCategory`, but we don't support multiple inheritance yet.
+FIXME: This signature should extend both `MonoidalCategoryWithDiagonals` and
+`MonoidalCategoryWithCodiagonals`, but we don't support multiple inheritance.
 """
-@signature SymmetricMonoidalCategory(Ob,Hom) => BiproductCategory(Ob,Hom) begin
+@signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithBidiagonals(Ob,Hom) begin
   mcopy(A::Ob)::Hom(A,otimes(A,A))
   mmerge(A::Ob)::Hom(otimes(A,A),A)
   delete(A::Ob)::Hom(A,munit())
@@ -226,10 +228,34 @@ FIXME: This signature should extend both `CartesianCategory` and
   □(A::Ob) = create(A)
 end
 
+""" Doctrine of *bicategory category*
+
+Also known as a *semiadditive category*.
+
+FIXME: This signature should extend `MonoidalCategoryWithBidiagonals`,
+`CartesianCategory`, and `CocartesianCategory`, but we don't support multiple
+inheritance.
+"""
+@signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BiproductCategory(Ob,Hom) begin
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) <= (A::Ob, B::Ob, C::Ob)
+  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) <= (A::Ob, B::Ob, C::Ob)
+  proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
+  proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
+  incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
+  incl2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
+end
+
 @syntax FreeBiproductCategory(ObExpr,HomExpr) BiproductCategory begin
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
+
+  pair(f::Hom, g::Hom) = compose(mcopy(dom(f)), otimes(f,g))
+  copair(f::Hom, g::Hom) = compose(otimes(f,g), mmerge(codom(f)))
+  proj1(A::Ob, B::Ob) = otimes(id(A), delete(B))
+  proj2(A::Ob, B::Ob) = otimes(delete(A), id(B))
+  incl1(A::Ob, B::Ob) = otimes(id(A), create(B))
+  incl2(A::Ob, B::Ob) = otimes(create(A), id(B))
 end
 
 # Cartesian closed category

--- a/src/doctrines/Relations.jl
+++ b/src/doctrines/Relations.jl
@@ -11,29 +11,24 @@ TODO: The 2-morphisms are missing. I haven't decided how to handle them yet.
 
 References:
 
-- (Carboni & Walters, 1987, "Cartesian bicategories I")
-- (Walters, 2009, blog post, "Categorical algebras of relations",
-   http://rfcwalters.blogspot.com/2009/10/categorical-algebras-of-relations.html)
+- Carboni & Walters, 1987, "Cartesian bicategories I"
+- Walters, 2009, blog post, "Categorical algebras of relations",
+  http://rfcwalters.blogspot.com/2009/10/categorical-algebras-of-relations.html
 """
-@signature SymmetricMonoidalCategory(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
+@signature MonoidalCategoryWithDiagonals(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
   # Dagger category.
   dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob,B::Ob)
   
   # Self-dual compact closed category.
   dunit(A::Ob)::Hom(munit(), otimes(A,A))
   dcounit(A::Ob)::Hom(otimes(A,A), munit())
-  
-  # Diagonal and codiagonal.
-  mcopy(A::Ob)::Hom(A,otimes(A,A))
-  delete(A::Ob)::Hom(A,munit())
-  mmerge(A::Ob)::Hom(otimes(A,A),A)
-  create(A::Ob)::Hom(munit(),A)
 end
 
 @syntax FreeBicategoryRelations(ObExpr,HomExpr) BicategoryRelations begin
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
+
   function dagger(f::Hom)
     f = anti_involute(Super.dagger(f), dagger, compose, id)
     distribute_unary(f, dagger, otimes)
@@ -46,8 +41,8 @@ Unlike Carboni & Walters, we use additive notation and nomenclature.
 
 References:
 
-- (Carboni & Walters, 1987, "Cartesian bicategories I", Sec. 5)
-- (Baez & Erbele, 2015, "Categories in control")
+- Carboni & Walters, 1987, "Cartesian bicategories I", Sec. 5
+- Baez & Erbele, 2015, "Categories in control"
 """
 @signature BicategoryRelations(Ob,Hom) => AbelianBicategoryRelations(Ob,Hom) begin
   # Second diagonal and codiagonal.
@@ -61,6 +56,7 @@ end
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
+  
   function dagger(f::Hom)
     f = anti_involute(Super.dagger(f), dagger, compose, id)
     distribute_unary(f, dagger, otimes)

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -41,7 +41,8 @@ using LightGraphs, MetaGraphs
 import LightGraphs: all_neighbors, neighbors, outneighbors, inneighbors
 
 using ...GAT, ...Syntax
-import ...Doctrines: CategoryExpr, ObExpr, HomExpr, SymmetricMonoidalCategory,
+import ...Doctrines:
+  CategoryExpr, ObExpr, HomExpr, MonoidalCategoryWithBidiagonals,
   dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
 
 # Data types
@@ -715,12 +716,9 @@ function WiringDiagram(f::HomExpr)
   return d
 end
 
-""" Wiring diagram as *symmetric monoidal category*.
-
-Wiring diagrams also have *diagonals* and *codiagonals* (see extra methods),
-but we don't have doctrines for those yet.
+""" Wiring diagram as *monoidal category with diagonals and codiagonals*.
 """
-@instance SymmetricMonoidalCategory(Ports, WiringDiagram) begin
+@instance MonoidalCategoryWithBidiagonals(Ports, WiringDiagram) begin
   dom(f::WiringDiagram) = Ports(f.input_ports)
   codom(f::WiringDiagram) = Ports(f.output_ports)
   
@@ -770,6 +768,11 @@ but we don't have doctrines for those yet.
     add_wires!(h, ((input_id(h),i+m) => (output_id(h),i) for i in 1:n))
     return h
   end
+
+  mcopy(A::Ports) = mcopy(A, 2)
+  mmerge(A::Ports) = mmerge(A, 2)
+  delete(A::Ports) = WiringDiagram(A, munit(Ports))
+  create(A::Ports) = WiringDiagram(munit(Ports), A)
 end
 
 function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
@@ -786,7 +789,7 @@ function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
   end
 end
 
-function mcopy(A::Ports, n::Int=2)::WiringDiagram
+function mcopy(A::Ports, n::Int)::WiringDiagram
   f = WiringDiagram(A, otimes([A for j in 1:n]))
   m = length(A)
   for j in 1:n
@@ -795,7 +798,7 @@ function mcopy(A::Ports, n::Int=2)::WiringDiagram
   return f
 end
 
-function mmerge(A::Ports, n::Int=2)::WiringDiagram
+function mmerge(A::Ports, n::Int)::WiringDiagram
   f = WiringDiagram(otimes([A for j in 1:n]), A)
   m = length(A)
   for j in 1:n
@@ -803,9 +806,6 @@ function mmerge(A::Ports, n::Int=2)::WiringDiagram
   end
   return f
 end
-
-delete(A::Ports) = WiringDiagram(A, munit(Ports))
-create(A::Ports) = WiringDiagram(munit(Ports), A)
 
 """ Convert a syntactic expression into a wiring diagram.
 

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -33,8 +33,8 @@ export AbstractBox, Box, WiringDiagram, Wire, Ports, PortValueError, Port,
   graph, add_box!, add_boxes!, add_wire!, add_wires!, validate_ports,
   rem_box!, rem_boxes!, rem_wire!, rem_wires!, substitute!, encapsulate!,
   all_neighbors, neighbors, outneighbors, inneighbors, in_wires, out_wires,
-  dom, codom, id, compose, otimes, munit, braid, permute, mcopy, delete,
-  mmerge, create, to_wiring_diagram
+  dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create,
+  permute, to_wiring_diagram
 
 using AutoHashEquals
 using LightGraphs, MetaGraphs
@@ -289,7 +289,7 @@ end
 function has_wire(f::WiringDiagram, wire::Wire)
   wire in wires(f, wire.source.box, wire.target.box)
 end
-has_wire(f, pair::Pair) = has_wire(f, Wire(pair))
+has_wire(f::WiringDiagram, pair::Pair) = has_wire(f, Wire(pair))
 
 function port_value(f::WiringDiagram, port::Port)
   if port.box == input_id(f)

--- a/src/wiring_diagrams/Layers.jl
+++ b/src/wiring_diagrams/Layers.jl
@@ -1,11 +1,11 @@
 """ Data structure for connecting one layer to another by wires.
 
 This module defines a generic data structure to represent a wiring between one
-layer of input ports to another layer of output ports. A wiring layer forms
+layer of input ports and another layer of output ports. A wiring layer forms a
 bipartite graph with independent edge sets the input ports and the output ports.
 
 Unlike wiring diagrams, wiring layers are an auxillary data structure. They are
-not terribly interesting in their own right, but they are useful intermediate
+not terribly interesting in their own right, but they are a useful intermediate
 representation in some circumstances. For example, a morphism expression
 comprised of generators, compositions, products, and wiring layers is
 intermediate between a pure GAT expression (which has no wiring layers, but may
@@ -14,7 +14,8 @@ graphical.
 """
 module WiringLayers
 export WiringLayer, Layer, input_ports, output_ports, nwires, wires, has_wire,
-  add_wire!, add_wires!, rem_wire!, rem_wires!, to_wiring_diagram,
+  add_wire!, add_wires!, rem_wire!, rem_wires!, in_wires, out_wires,
+  to_wiring_diagram,
   dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
 
 using AutoHashEquals
@@ -24,7 +25,8 @@ import ...Doctrines: MonoidalCategoryWithBidiagonals,
   dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
 using ..WiringDiagramCore
 import ..WiringDiagramCore: input_ports, output_ports, nwires, wires, has_wire,
-  add_wire!, add_wires!, rem_wire!, rem_wires!, to_wiring_diagram
+  add_wire!, add_wires!, rem_wire!, rem_wires!, in_wires, out_wires,
+  to_wiring_diagram
 
 # Data types
 ############
@@ -34,12 +36,12 @@ import ..WiringDiagramCore: input_ports, output_ports, nwires, wires, has_wire,
 Morphism in the category of wiring layers.
 """
 @auto_hash_equals struct WiringLayer{T}
-  wires::Dict{Pair{Int,Int},Int} # Multiset of wires
+  wires::Dict{Int}{Dict{Int}{Int}} # src -> tgt -> multiplicity
   input_ports::Vector{T}
   output_ports::Vector{T}
 
-  function WiringLayer(inputs::Vector{T}, outputs::Vector{T}) where T
-    new{T}(Dict{Pair{Int,Int},Int}(), inputs, outputs)
+  function WiringLayer(inputs::Vector{T}, outputs::Vector{S}) where {T,S}
+    new{promote_type(T,S)}(Dict{Int}{Dict{Int}{Int}}(), inputs, outputs)
   end
 end
 
@@ -50,6 +52,8 @@ Object in the category of wiring layers.
 @auto_hash_equals struct Layer{T}
   ports::Vector{T}
 end
+Base.eachindex(layer::Layer) = eachindex(layer.ports)
+Base.length(layer::Layer) = length(layer.ports)
 
 # Low-level graph interface
 ###########################
@@ -63,23 +67,29 @@ end
 input_ports(f::WiringLayer) = f.input_ports
 output_ports(f::WiringLayer) = f.output_ports
 
-nwires(f::WiringLayer) = sum(values(f.wires))
-nwires(f::WiringLayer, wire) = get(f.wires, wire, 0)
 has_wire(f::WiringLayer, wire) = nwires(f, wire) > 0
-wires(f::WiringLayer) = vcat((repeat([wire],n) for (wire,n) in f.wires)...)
+
+function nwires(f::WiringLayer, wire)
+  src, tgt = wire
+  get(get(f.wires, src, Dict()), tgt, 0)
+end
+
+nwires(f::WiringLayer) = sum(Int[ sum(values(d)) for d in values(f.wires) ])
+wires(f::WiringLayer) = vcat((out_wires(f, src) for src in keys(f.wires))...)
+
+function out_wires(f::WiringLayer, src::Int)
+  tgts = get(f.wires, src, Dict())
+  vcat((repeat([src => tgt], n) for (tgt, n) in tgts)...)
+end
 
 function add_wire!(f::WiringLayer, wire)
+  check_wire_bounds(f, wire)
   src, tgt = wire
-  if !(1 <= src <= length(f.input_ports))
-    throw(BoundsError("layer inputs $(f.input_ports)", src))
-  end
-  if !(1 <= tgt <= length(f.output_ports))
-    throw(BoundsError("layer outputs $(f.output_ports)", tgt))
-  end
-  if haskey(f.wires, wire)
-    f.wires[wire] += 1
+  counts = get!(f.wires, src, Dict{Int}{Int}())
+  if haskey(counts, tgt)
+    counts[tgt] += 1
   else
-    f.wires[wire] = 1
+    counts[tgt] = 1
   end
 end
 
@@ -90,14 +100,110 @@ function add_wires!(f::WiringLayer, wires)
 end
 
 function rem_wire!(f::WiringLayer, wire)
-  if f.wires[wire] <= 1
-    delete!(f.wires, wire)
+  src, tgt = wire
+  counts = f.wires[src]
+  if counts[tgt] > 1
+    counts[tgt] -= 1
   else
-    f.wires[wire] -= 1
+    delete!(counts, tgt)
+  end
+  if isempty(counts)
+    delete!(f.wires, src)
   end
 end
 
-rem_wires!(f::WiringLayer, wire) = delete!(f.wires, wire)
+function rem_wires!(f::WiringLayer, wire)
+  src, tgt = wire
+  counts = get(f.wires, src, Dict())
+  pop!(counts, tgt, nothing)
+  if isempty(counts)
+    pop!(f.wires, src, nothing)
+  end
+end
+
+function check_wire_bounds(f::WiringLayer, wire)
+  src, tgt = wire
+  if !(1 <= src <= length(f.input_ports))
+    throw(BoundsError("layer inputs $(f.input_ports)", src))
+  end
+  if !(1 <= tgt <= length(f.output_ports))
+    throw(BoundsError("layer outputs $(f.output_ports)", tgt))
+  end
+end
+
+# High-level categorical interface
+##################################
+
+function WiringLayer(inputs::Layer, outputs::Layer)
+  WiringLayer(inputs.ports, outputs.ports)
+end
+
+""" Wiring layers as *monoidal category with diagonals and codiagonals*.
+"""
+@instance MonoidalCategoryWithBidiagonals(Layer, WiringLayer) begin
+  dom(f::WiringLayer) = Layer(f.input_ports)
+  codom(f::WiringLayer) = Layer(f.output_ports)
+
+  function id(A::Layer)
+    f = WiringLayer(A, A)
+    add_wires!(f, i=>i for i in eachindex(A))
+    f
+  end
+  
+  function compose(f::WiringLayer, g::WiringLayer)
+    if codom(f) != dom(g)
+      error("Incompatible domains $(codom(f)) and $(dom(g))")
+    end
+    h = WiringLayer(dom(f), codom(g))
+    for (src, mid) in wires(f)
+      for (_, tgt) in out_wires(g, mid)
+        add_wire!(h, src => tgt)
+      end
+    end
+    h
+  end
+  
+  otimes(A::Layer, B::Layer) = Layer([A.ports; B.ports])
+  munit(::Type{Layer}) = Layer([])
+  
+  function otimes(f::WiringLayer, g::WiringLayer)
+    h = WiringLayer(otimes(dom(f),dom(g)), otimes(codom(f),codom(g)))
+    m, n = length(dom(f)), length(codom(f))
+    add_wires!(h, wires(f))
+    add_wires!(h, src+m => tgt+n for (src, tgt) in wires(g))
+    h
+  end
+  
+  function braid(A::Layer, B::Layer)
+    f = WiringLayer(otimes(A,B), otimes(B,A))
+    m, n = length(A), length(B)
+    add_wires!(f, i => i+n for i in 1:m)
+    add_wires!(f, i+m => i for i in 1:n)
+    f
+  end
+
+  mcopy(A::Layer) = mcopy(A, 2)
+  mmerge(A::Layer) = mmerge(A, 2)
+  delete(A::Layer) = WiringLayer(A, munit(Layer))
+  create(A::Layer) = WiringLayer(munit(Layer), A)
+end
+
+function mcopy(A::Layer, n::Int)
+  f = WiringLayer(A, otimes([A for j in 1:n]))
+  m = length(A)
+  add_wires!(f, i => i+m*(j-1) for i in 1:m, j in 1:n)
+  f
+end
+
+function mmerge(A::Layer, n::Int)
+  f = WiringLayer(otimes([A for j in 1:n]), A)
+  m = length(A)
+  add_wires!(f, i+m*(j-1) => i for i in 1:m, j in 1:n)
+  f
+end
+
+# Conversion
+############
 
 function to_wiring_diagram(f::WiringLayer)
   diagram = WiringDiagram(input_ports(f), output_ports(f))
@@ -105,15 +211,5 @@ function to_wiring_diagram(f::WiringLayer)
                        for (src, tgt) in sort!(wires(f))))
   diagram
 end
-
-# High-level categorical interface
-##################################
-
-# """ Wiring layers as *monoidal category with diagonals and codiagonals*.
-# """
-# @instance MonoidalCategoryWithBidiagonals(Layer, WiringLayer) begin
-#   dom(f::WiringLayer) = Layer(f.inputs)
-#   codom(f::WiringLayer) = Layer(f.outputs)
-# end
 
 end

--- a/src/wiring_diagrams/Layers.jl
+++ b/src/wiring_diagrams/Layers.jl
@@ -21,9 +21,10 @@ export WiringLayer, Layer, input_ports, output_ports, nwires, wires, has_wire,
 using AutoHashEquals
 
 using ...GAT, ...Syntax
-import ...Doctrines: MonoidalCategoryWithBidiagonals,
+import ...Doctrines: ObExpr, HomExpr, MonoidalCategoryWithBidiagonals,
   dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
 using ..WiringDiagramCore
+using ..WiringDiagramCore: collect_values
 import ..WiringDiagramCore: input_ports, output_ports, nwires, wires, has_wire,
   add_wire!, add_wires!, rem_wire!, rem_wires!, in_wires, out_wires,
   to_wiring_diagram
@@ -134,6 +135,11 @@ end
 # High-level categorical interface
 ##################################
 
+Layer(ob::ObExpr) = Layer(collect_values(ob))
+
+function WiringLayer(inputs::ObExpr, outputs::ObExpr)
+  WiringLayer(collect_values(inputs), collect_values(outputs))
+end
 function WiringLayer(inputs::Layer, outputs::Layer)
   WiringLayer(inputs.ports, outputs.ports)
 end

--- a/src/wiring_diagrams/Layers.jl
+++ b/src/wiring_diagrams/Layers.jl
@@ -1,0 +1,119 @@
+""" Data structure for connecting one layer to another by wires.
+
+This module defines a generic data structure to represent a wiring between one
+layer of input ports to another layer of output ports. A wiring layer forms
+bipartite graph with independent edge sets the input ports and the output ports.
+
+Unlike wiring diagrams, wiring layers are an auxillary data structure. They are
+not terribly interesting in their own right, but they are useful intermediate
+representation in some circumstances. For example, a morphism expression
+comprised of generators, compositions, products, and wiring layers is
+intermediate between a pure GAT expression (which has no wiring layers, but may
+have identities, braidings, copies, etc.) and a wiring diagram, which is purely
+graphical.
+"""
+module WiringLayers
+export WiringLayer, Layer, input_ports, output_ports, nwires, wires, has_wire,
+  add_wire!, add_wires!, rem_wire!, rem_wires!, to_wiring_diagram,
+  dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
+
+using AutoHashEquals
+
+using ...GAT, ...Syntax
+import ...Doctrines: MonoidalCategoryWithBidiagonals,
+  dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
+using ..WiringDiagramCore
+import ..WiringDiagramCore: input_ports, output_ports, nwires, wires, has_wire,
+  add_wire!, add_wires!, rem_wire!, rem_wires!, to_wiring_diagram
+
+# Data types
+############
+
+""" Connection by wires of one layer to another.
+
+Morphism in the category of wiring layers.
+"""
+@auto_hash_equals struct WiringLayer{T}
+  wires::Dict{Pair{Int,Int},Int} # Multiset of wires
+  input_ports::Vector{T}
+  output_ports::Vector{T}
+
+  function WiringLayer(inputs::Vector{T}, outputs::Vector{T}) where T
+    new{T}(Dict{Pair{Int,Int},Int}(), inputs, outputs)
+  end
+end
+
+""" A layer, constituted by a list of ports.
+
+Object in the category of wiring layers.
+"""
+@auto_hash_equals struct Layer{T}
+  ports::Vector{T}
+end
+
+# Low-level graph interface
+###########################
+
+function WiringLayer(wires, inputs, outputs)
+  f = WiringLayer(inputs, outputs)
+  add_wires!(f, wires)
+  f
+end
+
+input_ports(f::WiringLayer) = f.input_ports
+output_ports(f::WiringLayer) = f.output_ports
+
+nwires(f::WiringLayer) = sum(values(f.wires))
+nwires(f::WiringLayer, wire) = get(f.wires, wire, 0)
+has_wire(f::WiringLayer, wire) = nwires(f, wire) > 0
+wires(f::WiringLayer) = vcat((repeat([wire],n) for (wire,n) in f.wires)...)
+
+function add_wire!(f::WiringLayer, wire)
+  src, tgt = wire
+  if !(1 <= src <= length(f.input_ports))
+    throw(BoundsError("layer inputs $(f.input_ports)", src))
+  end
+  if !(1 <= tgt <= length(f.output_ports))
+    throw(BoundsError("layer outputs $(f.output_ports)", tgt))
+  end
+  if haskey(f.wires, wire)
+    f.wires[wire] += 1
+  else
+    f.wires[wire] = 1
+  end
+end
+
+function add_wires!(f::WiringLayer, wires)
+  for wire in wires
+    add_wire!(f, wire)
+  end
+end
+
+function rem_wire!(f::WiringLayer, wire)
+  if f.wires[wire] <= 1
+    delete!(f.wires, wire)
+  else
+    f.wires[wire] -= 1
+  end
+end
+
+rem_wires!(f::WiringLayer, wire) = delete!(f.wires, wire)
+
+function to_wiring_diagram(f::WiringLayer)
+  diagram = WiringDiagram(input_ports(f), output_ports(f))
+  add_wires!(diagram, ((input_id(diagram), src) => (output_id(diagram), tgt)
+                       for (src, tgt) in sort!(wires(f))))
+  diagram
+end
+
+# High-level categorical interface
+##################################
+
+# """ Wiring layers as *monoidal category with diagonals and codiagonals*.
+# """
+# @instance MonoidalCategoryWithBidiagonals(Layer, WiringLayer) begin
+#   dom(f::WiringLayer) = Layer(f.inputs)
+#   codom(f::WiringLayer) = Layer(f.outputs)
+# end
+
+end

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -3,12 +3,14 @@ module WiringDiagrams
 using Reexport
 
 include("Core.jl")
+include("Layers.jl")
 include("Algorithms.jl")
 include("Serialization.jl")
 include("GraphML.jl")
 include("JSON.jl")
 
 @reexport using .WiringDiagramCore
+@reexport using .WiringLayers
 @reexport using .WiringDiagramAlgorithms
 @reexport using .GraphMLWiringDiagrams
 @reexport using .JSONWiringDiagrams

--- a/test/Doctrines.jl
+++ b/test/Doctrines.jl
@@ -196,8 +196,8 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 
 # Derived syntax
 @test copair(f,f) == compose(otimes(f,f), mmerge(B))
-@test in1(A,B) == otimes(id(A), create(B))
-@test in2(A,B) == otimes(create(A), id(B))
+@test incl1(A,B) == otimes(id(A), create(B))
+@test incl2(A,B) == otimes(create(A), id(B))
 
 # Infix notation (LaTeX)
 @test latex(mmerge(A)) == "\\nabla_{A}"

--- a/test/algebra/Network.jl
+++ b/test/algebra/Network.jl
@@ -96,7 +96,9 @@ f_comp = compile(f)
 # Wiring layers
 wires = [ 1 => 3, 1 => 2, 2 => 2, 3 => 2, 3 => 1 ]
 f = to_algebraic_net(WiringLayer(wires, otimes(R,R,R), otimes(R,R,R)))
-@test collect(evaluate(f,x,y,z)) ≈ [z, x+y+z, x]
+f_comp = compile(f)
+@test f_comp(x,y,z) == (z, x+y+z, x)
+@test evaluate(f,x,y,z) == (z, x+y+z, x)
 
 # More complex expressions
 f = compose(otimes(id(R),constant(1,R)), mmerge(R))

--- a/test/algebra/Network.jl
+++ b/test/algebra/Network.jl
@@ -6,10 +6,10 @@ using Test
 using Catlab.Algebra
 using Catlab.Syntax
 
-unicode(expr::GATExpr) = sprint(show_unicode, expr)
-latex(expr::GATExpr) = sprint(show_latex, expr)
-
 R = Ob(AlgebraicNet, :R)
+
+# Compilation and evaluation
+############################
 
 # Generator
 x = collect(range(-2,stop=2,length=50))
@@ -23,16 +23,12 @@ f_comp = compile(f,name=:myfun)
 f_comp = compile(f,name=:myfun2,args=[:x])
 @test f_comp(x) == sin.(x)
 @test evaluate(f,x) == sin.(x)
-@test unicode(f) == "sin"
-@test latex(f) == "\\mathrm{sin}"
 
 # Composition
 f = compose(linear(2,R,R), Hom(:sin,R,R))
 f_comp = compile(f)
 @test f_comp(x) == sin.(2x)
 @test evaluate(f,x) == sin.(2x)
-@test unicode(f) == "linear[2]; sin"
-@test latex(f) == "\\mathop{\\mathrm{linear}}\\left[2\\right] ; \\mathrm{sin}"
 
 f = compose(linear(2,R,R), Hom(:sin,R,R), linear(2,R,R))
 f_comp = compile(f)
@@ -47,67 +43,67 @@ f_comp = compile(f)
 f_comp = compile(f,args=[:x,:y])
 @test f_comp(x,y) == (cos.(x),sin.(y))
 @test evaluate(f,x,y) == (cos.(x),sin.(y))
-@test unicode(f) == "cos⊗sin"
-@test latex(f) == "\\mathrm{cos} \\otimes \\mathrm{sin}"
 
 # Braiding
 f = braid(R,R)
 f_comp = compile(f)
 @test f_comp(x,y) == (y,x)
 @test evaluate(f,x,y) == (y,x)
+
 f = compose(braid(R,R), otimes(Hom(:cos,R,R), Hom(:sin,R,R)))
 f_comp = compile(f)
 @test f_comp(x,y) == (cos.(y),sin.(x))
 @test evaluate(f,x,y) == (cos.(y),sin.(x))
 
-f = compose(otimes(id(R),constant(1,R)), mmerge(R))
-f_comp = compile(f)
-@test f_comp(x) == @. x+1
-@test evaluate(f,x) == @. x+1
-@test unicode(f) == "(id[R]⊗1); mmerge[R,2]"
-@test latex(f) == "\\left(\\mathrm{id}_{R} \\otimes 1\\right) ; \\nabla_{R,2}"
-
-f = compose(otimes(id(R),constant((1,1),otimes(R,R))), mmerge(R,3))
-f_comp = compile(f)
-@test f_comp(x) ≈ @. x+2
-@test evaluate(f,x) ≈ @. x+2
-
-# Copy
+# Diagonals
 f = mcopy(R)
 f_comp = compile(f)
 @test f_comp(x) == (x,x)
 @test evaluate(f,x) == (x,x)
+
 f = mcopy(R,3)
 f_comp = compile(f)
 @test f_comp(x) == (x,x,x)
 @test evaluate(f,x) == (x,x,x)
+
+f = compose(mcopy(R), otimes(id(R), delete(R)))
+f_comp = compile(f)
+@test f_comp(x) == x
+@test evaluate(f,x) == x
 
 f = compose(mcopy(R), otimes(Hom(:cos,R,R), Hom(:sin,R,R)))
 f_comp = compile(f)
 @test f_comp(x) == (cos.(x),sin.(x))
 @test evaluate(f,x) == (cos.(x),sin.(x))
 
-# Merge
+# Codiagonals
 z = collect(range(-4,stop=0,length=50))
 f = mmerge(R)
 f_comp = compile(f)
 @test f_comp(x,y) == @. x+y
 @test evaluate(f,x,y) == @. x+y
+
 f = mmerge(R,3)
 f_comp = compile(f)
 @test f_comp(x,y,z) == @. x+y+z
 @test evaluate(f,x,y,z) == @. x+y+z
 
-f = compose(mcopy(R), otimes(id(R), delete(R)))
-f_comp = compile(f)
-@test f_comp(x) == x
-@test evaluate(f,x) == x
 f = compose(otimes(id(R), create(R)), mmerge(R))
 f_comp = compile(f)
 @test f_comp(x) == x
 @test evaluate(f,x) == x
 
-# Deeper compositions
+# More complex expressions
+f = compose(otimes(id(R),constant(1,R)), mmerge(R))
+f_comp = compile(f)
+@test f_comp(x) == @. x+1
+@test evaluate(f,x) == @. x+1
+
+f = compose(otimes(id(R),constant((1,1),otimes(R,R))), mmerge(R,3))
+f_comp = compile(f)
+@test f_comp(x) ≈ @. x+2
+@test evaluate(f,x) ≈ @. x+2
+
 f = compose(mcopy(R), otimes(Hom(:cos,R,R), Hom(:sin,R,R)), mmerge(R))
 f_comp = compile(f)
 @test f_comp(x) == @. cos(x) + sin(x)
@@ -132,7 +128,7 @@ target = dropdims(sum([x y]*A', dims=2), dims=2)
 @test f_comp(x,y) ≈ target
 @test evaluate(f,x,y) ≈ target
 
-# Symbolic coefficients
+# Compilation with symbolic coefficients
 f = linear(:c, R, R)
 f_comp = compile(f)
 @test f_comp(x,c=1) == x
@@ -153,5 +149,31 @@ f_comp, f_const = compile(f, return_constants=true, vector=true)
 f = compose(otimes(id(R),constant(:c,R)), mmerge(R))
 f_comp = compile(f,name=:myfun3)
 @test f_comp(x,c=2) ≈ @. x+2
+
+# Display
+#########
+
+unicode(expr::GATExpr) = sprint(show_unicode, expr)
+latex(expr::GATExpr) = sprint(show_latex, expr)
+
+# Generator
+f = Hom(:sin,R,R)
+@test unicode(f) == "sin"
+@test latex(f) == "\\mathrm{sin}"
+
+# Composition
+f = compose(linear(2,R,R), Hom(:sin,R,R))
+@test unicode(f) == "linear[2]; sin"
+@test latex(f) == "\\mathop{\\mathrm{linear}}\\left[2\\right] ; \\mathrm{sin}"
+
+# Monoidal product
+f = otimes(Hom(:cos,R,R), Hom(:sin,R,R))
+@test unicode(f) == "cos⊗sin"
+@test latex(f) == "\\mathrm{cos} \\otimes \\mathrm{sin}"
+
+# Diagonals and codiagonals
+f = compose(otimes(id(R),constant(1,R)), mmerge(R))
+@test unicode(f) == "(id[R]⊗1); mmerge[R,2]"
+@test latex(f) == "\\left(\\mathrm{id}_{R} \\otimes 1\\right) ; \\nabla_{R,2}"
 
 end

--- a/test/algebra/Network.jl
+++ b/test/algebra/Network.jl
@@ -3,8 +3,8 @@ module TestAlgebraicNetwork
 import Pkg
 using Test
 
-using Catlab.Algebra
 using Catlab.Syntax
+using Catlab.Algebra, Catlab.WiringDiagrams.WiringLayers
 
 R = Ob(AlgebraicNet, :R)
 
@@ -92,6 +92,11 @@ f = compose(otimes(id(R), create(R)), mmerge(R))
 f_comp = compile(f)
 @test f_comp(x) == x
 @test evaluate(f,x) == x
+
+# Wiring layers
+wires = [ 1 => 3, 1 => 2, 2 => 2, 3 => 2, 3 => 1 ]
+f = to_algebraic_net(WiringLayer(wires, otimes(R,R,R), otimes(R,R,R)))
+@test collect(evaluate(f,x,y,z)) ≈ [z, x+y+z, x]
 
 # More complex expressions
 f = compose(otimes(id(R),constant(1,R)), mmerge(R))

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -1,8 +1,7 @@
 module TestWiringDiagramCore
 
 using Test
-using Catlab.Doctrines
-using Catlab.WiringDiagrams
+using Catlab.Doctrines, Catlab.WiringDiagrams
 
 # For testing purposes, check equality of port symbols.
 function WiringDiagramCore.validate_ports(source_port::Symbol, target_port::Symbol)

--- a/test/wiring_diagrams/Layers.jl
+++ b/test/wiring_diagrams/Layers.jl
@@ -1,0 +1,37 @@
+module TestWiringLayers
+
+using Test
+using Catlab.Doctrines, Catlab.WiringDiagrams
+
+# Low-level graph interface
+###########################
+
+A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
+
+f = WiringLayer([A, B, C], [C, B, A])
+@test input_ports(f) == [A, B, C]
+@test output_ports(f) == [C, B, A]
+@test nwires(f) == 0
+@test wires(f) == []
+
+add_wire!(f, 1 => 3)
+@test has_wire(f, 1 => 3)
+@test !has_wire(f, 3 => 1)
+@test_throws BoundsError add_wire!(f, 4 => 1) # Source out of bounds
+@test_throws BoundsError add_wire!(f, 1 => 4) # Target out of bounds
+
+add_wires!(f, [2 => 2, 3 => 1])
+@test nwires(f) == 3
+@test sort!(wires(f)) == [1 => 3, 2 => 2, 3 => 1]
+
+@test nwires(f, 1 => 3) == 1
+add_wires!(f, [1 => 3, 1 => 3])
+@test nwires(f, 1 => 3) == 3
+@test sort!(wires(f)) == [1 => 3, 1 => 3, 1 => 3, 2 => 2, 3 => 1]
+rem_wire!(f, 1 => 3)
+@test nwires(f, 1 => 3) == 2
+rem_wires!(f, 1 => 3)
+@test !has_wire(f, f => 3)
+@test nwires(f, 1 => 3) == 0
+
+end

--- a/test/wiring_diagrams/Layers.jl
+++ b/test/wiring_diagrams/Layers.jl
@@ -22,19 +22,19 @@ add_wire!(f, 1 => 3)
 
 add_wires!(f, [2 => 2, 3 => 1])
 @test nwires(f) == 3
-@test sort!(wires(f)) == [1 => 3, 2 => 2, 3 => 1]
+@test wires(f) == [1 => 3, 2 => 2, 3 => 1]
 
 @test nwires(f, 1 => 3) == 1
 add_wires!(f, [1 => 3, 1 => 3])
 @test nwires(f, 1 => 3) == 3
-@test sort!(wires(f)) == [1 => 3, 1 => 3, 1 => 3, 2 => 2, 3 => 1]
+@test wires(f) == [1 => 3, 1 => 3, 1 => 3, 2 => 2, 3 => 1]
 @test out_wires(f, 1) == [1 => 3, 1 => 3, 1 => 3]
 rem_wire!(f, 1 => 3)
 @test nwires(f, 1 => 3) == 2
 rem_wires!(f, 1 => 3)
 @test !has_wire(f, f => 3)
 @test nwires(f, 1 => 3) == 0
-@test sort!(wires(f)) == [2 => 2, 3 => 1]
+@test wires(f) == [2 => 2, 3 => 1]
 
 # High-level categorical interface
 ##################################

--- a/test/wiring_diagrams/Layers.jl
+++ b/test/wiring_diagrams/Layers.jl
@@ -6,11 +6,11 @@ using Catlab.Doctrines, Catlab.WiringDiagrams
 # Low-level graph interface
 ###########################
 
-A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
+a, b, c = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
 
-f = WiringLayer([A, B, C], [C, B, A])
-@test input_ports(f) == [A, B, C]
-@test output_ports(f) == [C, B, A]
+f = WiringLayer([a, b, c], [c, b, a])
+@test input_ports(f) == [a, b, c]
+@test output_ports(f) == [c, b, a]
 @test nwires(f) == 0
 @test wires(f) == []
 
@@ -28,10 +28,38 @@ add_wires!(f, [2 => 2, 3 => 1])
 add_wires!(f, [1 => 3, 1 => 3])
 @test nwires(f, 1 => 3) == 3
 @test sort!(wires(f)) == [1 => 3, 1 => 3, 1 => 3, 2 => 2, 3 => 1]
+@test out_wires(f, 1) == [1 => 3, 1 => 3, 1 => 3]
 rem_wire!(f, 1 => 3)
 @test nwires(f, 1 => 3) == 2
 rem_wires!(f, 1 => 3)
 @test !has_wire(f, f => 3)
 @test nwires(f, 1 => 3) == 0
+@test sort!(wires(f)) == [2 => 2, 3 => 1]
+
+# High-level categorical interface
+##################################
+
+A, B, C = Layer([a]), Layer([b]), Layer([c])
+
+# Category
+@test compose(id(A), id(A)) == id(A)
+
+# Symmetric monoidal category
+@test otimes(id(A), id(B)) == id(otimes(A,B))
+@test compose(braid(A,B), braid(B,A)) == id(otimes(A,B))
+
+# Diagonals
+@test compose(otimes(mcopy(A), mcopy(B)), otimes(id(A), braid(A,B), id(B))) ==
+  mcopy(otimes(A,B))
+@test compose(mcopy(A), otimes(mcopy(A), id(A))) == mcopy(A, 3)
+@test compose(mcopy(A), otimes(id(A), mcopy(A))) == mcopy(A, 3)
+@test compose(mcopy(A), otimes(id(A), delete(A))) == id(A)
+
+# Codiagonals
+@test compose(otimes(id(A), braid(B,A), id(B)), otimes(mmerge(A), mmerge(B))) ==
+  mmerge(otimes(A,B))
+@test compose(otimes(mmerge(A), id(A)), mmerge(A)) == mmerge(A, 3)
+@test compose(otimes(id(A), mmerge(A)), mmerge(A)) == mmerge(A, 3)
+@test compose(otimes(id(A), create(A)), mmerge(A)) == id(A)
 
 end

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -4,6 +4,10 @@ using Test
   include("Core.jl")
 end
 
+@testset "Layers" begin
+  include("Layers.jl")
+end
+
 @testset "Algorithms" begin
   include("Algorithms.jl")
 end


### PR DESCRIPTION
From the code documentation:

> This module defines a generic data structure to represent a wiring between one
layer of input ports and another layer of output ports. A wiring layer forms a
bipartite graph with independent edge sets the input ports and the output ports.
>
> Unlike wiring diagrams, wiring layers are an auxillary data structure. They are
not terribly interesting in their own right, but they are a useful intermediate
representation in some circumstances. For example, a morphism expression
comprised of generators, compositions, products, and wiring layers is
intermediate between a pure GAT expression (which has no wiring layers, but may
have identities, braidings, copies, etc.) and a wiring diagram, which is purely
graphical.

As part of this PR, I had hoped to implement an algorithm to convert a wiring diagram into an alternating composition of monoidal products and wiring layers, but due to lack of urgent need I have postponed that.