### PR TITLE
Convert permutations to composities of braidings and identities

### DIFF
--- a/src/doctrines/Doctrines.jl
+++ b/src/doctrines/Doctrines.jl
@@ -26,4 +26,6 @@ include("Category.jl")
 include("Monoidal.jl")
 include("Relations.jl")
 
+include("Permutations.jl")
+
 end

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -41,7 +41,10 @@ otimes(x, y, z, xs...) = otimes([x, y, z, xs...])
 collect(expr::ObExpr) = [ expr ]
 collect(expr::ObExpr{:otimes}) = vcat(map(collect, args(expr))...)
 collect(expr::ObExpr{:munit}) = roottypeof(expr)[]
-roottypeof(x) = typeof(x).name.wrapper
+
+# XXX: We shouldn't have to do this.
+roottype(T) = T isa UnionAll ? T : T.name.wrapper
+roottypeof(x) = roottype(typeof(x))
 
 """ Number of "dimensions" of object in monoidal category.
 """

--- a/src/doctrines/Permutations.jl
+++ b/src/doctrines/Permutations.jl
@@ -6,6 +6,7 @@ doctrine, but I'm thinking the `Doctrines` top-level module should be renamed.
 module Permutations
 export decompose_permutation_by_bubble_sort!, permutation_to_expr
 
+using Compat
 using ...Syntax
 using ..Doctrines: dom, codom, compose, id, otimes, munit, braid
 

--- a/src/doctrines/Permutations.jl
+++ b/src/doctrines/Permutations.jl
@@ -6,7 +6,8 @@ doctrine, but I'm thinking the `Doctrines` top-level module should be renamed.
 module Permutations
 export decompose_permutation_by_bubble_sort!, permutation_to_expr
 
-using ..Doctrines: compose, id, otimes, munit, braid
+using ...Syntax
+using ..Doctrines: dom, codom, compose, id, otimes, munit, braid
 
 # Decomposition
 ###############
@@ -39,10 +40,31 @@ end
 ##########################
 
 """ Convert a typed permutation into a morphism expression.
+
+FIXME: The resulting expression is not simplified.
 """
-function permutation_to_expr(σ::Vector{Int}, objects::Vector)
-  @assert all(σ[i] == i for i in eachindex(σ)) "Conversion of non-identity not implemented"
-  id(otimes(objects))
+function permutation_to_expr(σ::Vector{Int}, xs::Vector)
+  permutation_to_expr!(copy(σ), copy(xs))
+end
+function permutation_to_expr!(σ::Vector{Int}, xs::Vector)
+  n = length(σ)
+  @assert length(xs) == n
+  
+  transpositions = decompose_permutation_by_bubble_sort!(σ)
+  if isempty(transpositions)
+    return id(otimes(xs))
+  end
+  
+  layers = map(transpositions) do τ
+    layer = [
+      τ > 1 ? id(otimes(xs[1:τ-1])) : nothing,
+      braid(xs[τ], xs[τ+1]),
+      τ+1 < n ? id(otimes(xs[τ+2:n])) : nothing,
+    ]
+    xs[τ], xs[τ+1] = xs[τ+1], xs[τ]
+    foldl(otimes, filter(!isnothing, layer))
+  end
+  foldl(compose, layers)
 end
 
 end

--- a/src/doctrines/Permutations.jl
+++ b/src/doctrines/Permutations.jl
@@ -4,10 +4,39 @@ FIXME: This doesn't really belong under `Doctrines`, since this isn't a
 doctrine, but I'm thinking the `Doctrines` top-level module should be renamed.
 """
 module Permutations
-export permutation_to_expr
+export decompose_permutation_by_bubble_sort!, permutation_to_expr
 
 using ..Doctrines: compose, id, otimes, munit, braid
 
+# Decomposition
+###############
+
+""" Decompose permutation into adjacent transpositions using bubble sort.
+
+An *adjacent transposition*, also known as a *simple transposition*, is a
+transposition of form (i i+1), represented here as simply the number i.
+
+This algorithm appears as Algorithm 2.7 in the PhD thesis of Jonathan Huang,
+"Probabilistic reasonsing and learning on permutations: Exploiting structural
+decompositions of the symmetric group". As Huang notes, the algorithm is
+very similar to the well-known bubble sort. It has quadratic complexity.
+"""
+function decompose_permutation_by_bubble_sort!(σ::Vector{Int})::Vector{Int}
+  n = length(σ)
+  result = Int[]
+  for i in 1:n
+    for j = n-1:-1:i
+      if σ[j+1] < σ[j]
+        σ[j], σ[j+1] = σ[j+1], σ[j]
+        push!(result, j)
+      end
+    end
+  end
+  result
+end
+
+# Conversion to expression
+##########################
 
 """ Convert a typed permutation into a morphism expression.
 """

--- a/src/doctrines/Permutations.jl
+++ b/src/doctrines/Permutations.jl
@@ -1,0 +1,19 @@
+""" Computer algebra of the symmetric group.
+
+FIXME: This doesn't really belong under `Doctrines`, since this isn't a
+doctrine, but I'm thinking the `Doctrines` top-level module should be renamed.
+"""
+module Permutations
+export permutation_to_expr
+
+using ..Doctrines: compose, id, otimes, munit, braid
+
+
+""" Convert a typed permutation into a morphism expression.
+"""
+function permutation_to_expr(σ::Vector{Int}, objects::Vector)
+  @assert all(σ[i] == i for i in eachindex(σ)) "Conversion of non-identity not implemented"
+  id(otimes(objects))
+end
+
+end

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -17,6 +17,7 @@ using LightGraphs
 
 using ...Syntax
 using ...Doctrines: id, compose, otimes, munit
+using ...Doctrines.Permutations
 using ..WiringDiagramCore, ..WiringLayers
 using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 
@@ -164,14 +165,7 @@ function to_hom_expr(layer::WiringLayer, inputs::Vector, outputs::Vector)
   σ = to_permutation(layer)
   @assert !isnothing(σ) "Conversion of non-permutation not implemented"
   @assert inputs == outputs
-  permutation_to_hom_expr(σ, inputs)
-end
-
-""" Convert a typed permutation into a morphism expression.
-"""
-function permutation_to_hom_expr(σ::Vector{Int}, objects::Vector)
-  @assert all(σ[i] == i for i in eachindex(σ)) "Conversion of non-identity not implemented"
-  id(otimes(objects))
+  permutation_to_expr(σ, inputs)
 end
 
 """ Convert a wiring layer into a permutation, if it is one.

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -164,7 +164,7 @@ The `inputs` and `outputs` are corresponding vectors of object expressions.
 function to_hom_expr(layer::WiringLayer, inputs::Vector, outputs::Vector)
   σ = to_permutation(layer)
   @assert !isnothing(σ) "Conversion of non-permutation not implemented"
-  @assert inputs == outputs
+  @assert inputs[σ] == outputs
   permutation_to_expr(σ, inputs)
 end
 

--- a/test/doctrines/Doctrines.jl
+++ b/test/doctrines/Doctrines.jl
@@ -8,7 +8,16 @@ sexpr(expr::GATExpr) = sprint(show_sexpr, expr)
 unicode(expr::GATExpr) = sprint(show_unicode, expr)
 latex(expr::GATExpr) = sprint(show_latex, expr)
 
-include("Category.jl")
-include("Monoidal.jl")
+@testset "Categories" begin
+  include("Category.jl")
+end
+
+@testset "MonoidalCategories" begin
+  include("Monoidal.jl")
+end
+
+@testset "Permutations" begin
+  include("Permutations.jl")
+end
 
 end

--- a/test/doctrines/Permutations.jl
+++ b/test/doctrines/Permutations.jl
@@ -1,0 +1,33 @@
+module TestPermutations
+
+using Test
+using Catlab.Doctrines, Catlab.Doctrines.Permutations
+
+# Decomposition
+###############
+
+const bubble = decompose_permutation_by_bubble_sort!
+
+# Permutations in S(1)
+@test bubble([1]) == []
+
+# Permutations in S(2)
+@test bubble([1,2]) == []
+@test bubble([2,1]) == [1]
+
+# Permutations in S(3)
+@test bubble([1,2,3]) == []
+@test bubble([2,1,3]) == [1]
+@test bubble([1,3,2]) == [2]
+@test bubble([2,3,1]) == [2,1]
+@test bubble([3,1,2]) == [1,2]
+@test bubble([3,2,1]) == [2,1,2]
+
+# Converson to expression
+#########################
+
+A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
+
+@test permutation_to_expr([1,2,3], [A,A,A]) == id(otimes(A,A,A))
+
+end

--- a/test/doctrines/Permutations.jl
+++ b/test/doctrines/Permutations.jl
@@ -28,6 +28,20 @@ const bubble = decompose_permutation_by_bubble_sort!
 
 A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
 
-@test permutation_to_expr([1,2,3], [A,A,A]) == id(otimes(A,A,A))
+# Permutations in S(1)
+@test permutation_to_expr([1], [A]) == id(A)
+
+# Permutations in S(2)
+@test permutation_to_expr([1,2], [A,B]) == id(otimes(A,B))
+@test permutation_to_expr([2,1], [A,B]) == braid(A,B)
+
+# Permutations in S(3)
+@test permutation_to_expr([1,2,3], [A,B,C]) == id(otimes(A,B,C))
+@test permutation_to_expr([2,1,3], [A,B,C]) == otimes(braid(A,B),id(C))
+@test permutation_to_expr([1,3,2], [A,B,C]) == otimes(id(A), braid(B,C))
+@test permutation_to_expr([2,3,1], [A,B,C]) ==
+  compose(otimes(id(A),braid(B,C)), otimes(braid(A,C),id(B)))
+@test permutation_to_expr([3,1,2], [A,B,C]) ==
+  compose(otimes(braid(A,B),id(C)), otimes(id(B),braid(A,C)))
 
 end

--- a/test/wiring_diagrams/Expressions.jl
+++ b/test/wiring_diagrams/Expressions.jl
@@ -83,8 +83,15 @@ expr = compose(m,otimes(f,id(B)),n)
 #####################
 
 # Identity.
-layer = id(NLayer(3))
-@test to_hom_expr(layer, repeat([A],3), repeat([A],3)) == id(otimes(A,A,A))
+layer = id(NLayer(2))
+@test to_hom_expr(layer, [A,B], [A,B]) == id(otimes(A,B))
+
+# Braidings.
+layer = braid(NLayer(1),NLayer(1))
+@test to_hom_expr(layer, [A,B], [B,A]) == braid(A,B)
+
+layer = otimes(id(NLayer(1)), braid(NLayer(1),NLayer(1)))
+@test to_hom_expr(layer, [A,B,C], [A,C,B]) == otimes(id(A),braid(B,C))
 
 # Graph operations
 ##################


### PR DESCRIPTION
In conjunction with previous PR #35, we can now convert wiring diagrams to morphism expressions in a symmetric monoidal category. The expressions are not simplified, but it's a start.