### PR TITLE
Reimplement substitution and encapsulation of wiring diagrams to preserve box order

### DIFF
--- a/src/wiring_diagrams/Algorithms.jl
+++ b/src/wiring_diagrams/Algorithms.jl
@@ -84,6 +84,9 @@ end
 """ Remove junction nodes from wiring diagram.
 
 Transforms from explicit to implicit representation of (co)diagonals.
+
+Note: This function currently does not actually mutate its argument. However,
+this is subject to change in the future.
 """
 function rem_junctions!(d::WiringDiagram)
   junction_ids = filter(v -> box(d,v) isa Junction, box_ids(d))
@@ -92,7 +95,7 @@ function rem_junctions!(d::WiringDiagram)
     layer = complete_layer(junction.ninputs, junction.noutputs)
     to_wiring_diagram(layer, input_ports(junction), output_ports(junction))
   end
-  substitute!(d, junction_ids, junction_diagrams)
+  substitute(d, junction_ids, junction_diagrams)
 end
 
 """ Put a wiring diagram for a cartesian category into normal form.

--- a/src/wiring_diagrams/Algorithms.jl
+++ b/src/wiring_diagrams/Algorithms.jl
@@ -93,7 +93,6 @@ function rem_junctions!(d::WiringDiagram)
     to_wiring_diagram(layer, input_ports(junction), output_ports(junction))
   end
   substitute!(d, junction_ids, junction_diagrams)
-  return d
 end
 
 """ Put a wiring diagram for a cartesian category into normal form.

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -26,7 +26,7 @@ export AbstractBox, Box, WiringDiagram, Wire, Ports, PortValueError, Port,
   wires, has_wire, graph, add_box!, add_boxes!, add_wire!, add_wires!,
   rem_box!, rem_boxes!, rem_wire!, rem_wires!, validate_ports,
   all_neighbors, neighbors, outneighbors, inneighbors, in_wires, out_wires,
-  substitute, substitute!, encapsulate, encapsulate!,
+  substitute, encapsulate, encapsulated_subdiagram,
   dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create,
   permute, is_permuted_equal
 
@@ -601,15 +601,6 @@ function substitute(d::WiringDiagram, vs::Vector{Int}, subs::Vector{WiringDiagra
   result
 end
 
-""" Mutating variant of `substitute`.
-
-Note: Currently the function does not actually mutate its argument. However,
-that is subject to change in the future.
-"""
-function substitute!(d::WiringDiagram, args...)
-  substitute(d, args...)
-end
-
 """ Substitute wires inside sub-diagram of a wiring diagram.
 """
 function _substitute_wires!(d::WiringDiagram, v::Int,
@@ -645,7 +636,7 @@ end
 
 """ Encapsulate multiple boxes within a single sub-diagram.
 
-This operation is a (one-sided) inverse to subsitution (see `substitute!`).
+This operation is a (one-sided) inverse to subsitution (see `substitute`).
 """
 function encapsulate(d::WiringDiagram, vs::Vector{Int};
                      discard_boxes::Bool=false, value::Any=nothing)
@@ -693,15 +684,6 @@ function encapsulate(d::WiringDiagram, vss::Vector{Vector{Int}};
     add_wire!(result, Wire(new_src, new_tgt))
   end
   result
-end
-
-""" Mutating variant of `encapsulate`.
-
-Note: Currently the function does not actually mutate its argument. However,
-that is subject to change in the future.
-"""
-function encapsulate!(d::WiringDiagram, args...; kw...)
-  encapsulate(d, args...; kw...)
 end
 
 """ Create an encapsulating box for a set of boxes in a wiring diagram.
@@ -831,7 +813,7 @@ Ports(expr::ObExpr) = Ports(collect_values(expr))
     add_wires!(h, ((input_id(h),i) => (fv,i) for i in eachindex(dom(f))))
     add_wires!(h, ((fv,i) => (gv,i) for i in eachindex(codom(f))))
     add_wires!(h, ((gv,i) => (output_id(h),i) for i in eachindex(codom(g))))
-    substitute!(h, [fv,gv])
+    substitute(h, [fv,gv])
   end
   
   otimes(A::Ports, B::Ports) = Ports([A.ports; B.ports])
@@ -846,7 +828,7 @@ Ports(expr::ObExpr) = Ports(collect_values(expr))
     add_wires!(h, (input_id(h),i+m) => (gv,i) for i in eachindex(dom(g)))
     add_wires!(h, (fv,i) => (output_id(h),i) for i in eachindex(codom(f)))
     add_wires!(h, (gv,i) => (output_id(h),i+n) for i in eachindex(codom(g)))
-    substitute!(h, [fv,gv])
+    substitute(h, [fv,gv])
   end
   
   function braid(A::Ports, B::Ports)

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -645,6 +645,7 @@ end
 
 function encapsulate(d::WiringDiagram, vss::Vector{Vector{Int}};
                      discard_boxes::Bool=false, values::Union{Nothing,Vector}=nothing)
+  if isempty(vss); return d end
   if any(isempty(vs) for vs in vss)
     error("Cannot encapsulate an empty set of boxes")
   end

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -60,13 +60,13 @@ function to_hom_expr(Ob::Type, Hom::Type, d::WiringDiagram)
   end
   
   # Step 1. Transitive reduction.
-  transitive_reduction!(Ob, d)
+  d = transitive_reduction!(Ob, d)
 
   # Step 2. Alternating series- and parallel-reduction.
   n = nboxes(d)
   while true
-    parallel_reduction!(Ob, Hom, d)
-    series_reduction!(Ob, Hom, d)
+    d = parallel_reduction!(Ob, Hom, d)
+    d = series_reduction!(Ob, Hom, d)
     # Repeat until the box count stops decreasing.
     nboxes(d) >= n && break
     n = nboxes(d)
@@ -76,7 +76,7 @@ function to_hom_expr(Ob::Type, Hom::Type, d::WiringDiagram)
   # one if there is no creation or deletion).
   if nboxes(d) > 1
     product = otimes(map(box_to_expr, box_ids(d)))
-    encapsulate!(d, box_ids(d), discard_boxes=true, value=product)
+    d = encapsulate!(d, box_ids(d), discard_boxes=true, value=product)
   end
   v = first(box_ids(d))
   foldl(compose_simplify_id, [
@@ -117,7 +117,7 @@ function parallel_reduction!(Ob::Type, Hom::Type, d::WiringDiagram)
   end
   
   if !isempty(parallel)
-    encapsulate!(d, parallel, discard_boxes=true, values=products)
+    d = encapsulate!(d, parallel, discard_boxes=true, values=products)
   end
   return d
 end
@@ -138,7 +138,7 @@ function series_reduction!(Ob::Type, Hom::Type, d::WiringDiagram)
   end
   
   if !isempty(series)
-    encapsulate!(d, series, discard_boxes=true, values=composites)
+    d = encapsulate!(d, series, discard_boxes=true, values=composites)
   end
   return d
 end

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -115,8 +115,7 @@ function parallel_reduction(Ob::Type, Hom::Type, d::WiringDiagram)
     push!(parallel, vs[σ])
     otimes(exprs[σ])
   end
-  isempty(parallel) ? d :
-    encapsulate(d, parallel, discard_boxes=true, values=products)
+  encapsulate(d, parallel, discard_boxes=true, values=products)
 end
 
 """ All possible series reductions of a wiring diagram.
@@ -133,8 +132,7 @@ function series_reduction(Ob::Type, Hom::Type, d::WiringDiagram)
     end
     foldl(compose_simplify_id, exprs)
   end
-  isempty(series) ? d :
-    encapsulate(d, series, discard_boxes=true, values=composites)
+  encapsulate(d, series, discard_boxes=true, values=composites)
 end
 
 """ All possible transitive reductions of a wiring diagram.

--- a/src/wiring_diagrams/GraphML.jl
+++ b/src/wiring_diagrams/GraphML.jl
@@ -24,7 +24,7 @@ using LightXML
 using LightGraphs, MetaGraphs
 
 using ..WiringDiagramCore, ..WiringDiagramSerialization
-import ..WiringDiagramCore: PortEdgeData
+import ..WiringDiagramCore: PortData
 
 # Data types
 ############
@@ -282,7 +282,7 @@ function parse_graphml_node(state::ReadState, xnode::XMLElement)
 end
 
 function parse_graphml_ports(state::ReadState, xnode::XMLElement)
-  ports = Dict{Tuple{String,String},PortEdgeData}()
+  ports = Dict{Tuple{String,String},PortData}()
   input_ports, output_ports = state.PortValue[], state.PortValue[]
   xnode_id = attribute(xnode, "id", required=true)
   xports = xnode["port"]
@@ -293,10 +293,10 @@ function parse_graphml_ports(state::ReadState, xnode::XMLElement)
     value = convert_from_graphml_data(state.PortValue, data)
     if port_kind == "input"
       push!(input_ports, value)
-      ports[(xnode_id, xport_name)] = PortEdgeData(InputPort, length(input_ports))
+      ports[(xnode_id, xport_name)] = PortData(InputPort, length(input_ports))
     elseif port_kind == "output"
       push!(output_ports, value)
-      ports[(xnode_id, xport_name)] = PortEdgeData(OutputPort, length(output_ports))
+      ports[(xnode_id, xport_name)] = PortData(OutputPort, length(output_ports))
     else
       error("Invalid port kind: $portkind")
     end

--- a/src/wiring_diagrams/JSON.jl
+++ b/src/wiring_diagrams/JSON.jl
@@ -22,7 +22,7 @@ using DataStructures: OrderedDict
 import JSON
 
 using ..WiringDiagramCore, ..WiringDiagramSerialization
-import ..WiringDiagramCore: PortEdgeData
+import ..WiringDiagramCore: PortData
 
 const JSONObject = OrderedDict{String,Any}
 
@@ -167,7 +167,7 @@ function parse_json_box(
 end
 
 function parse_json_ports(PortValue::Type, node::AbstractDict)
-  ports = Dict{Tuple{String,String},PortEdgeData}()
+  ports = Dict{Tuple{String,String},PortData}()
   input_ports, output_ports = PortValue[], PortValue[]
   node_id = node["id"]
   for port in node["ports"]
@@ -176,10 +176,10 @@ function parse_json_ports(PortValue::Type, node::AbstractDict)
     value = parse_json_graph_data(PortValue, port)
     if port_kind == "input"
       push!(input_ports, value)
-      ports[(node_id, port_id)] = PortEdgeData(InputPort, length(input_ports))
+      ports[(node_id, port_id)] = PortData(InputPort, length(input_ports))
     elseif port_kind == "output"
       push!(output_ports, value)
-      ports[(node_id, port_id)] = PortEdgeData(OutputPort, length(output_ports))
+      ports[(node_id, port_id)] = PortData(OutputPort, length(output_ports))
     else
       error("Invalid port kind: $portkind")
     end

--- a/test/programs/JuliaPrograms.jl
+++ b/test/programs/JuliaPrograms.jl
@@ -52,7 +52,7 @@ diagram = @parse_wiring_diagram C (v::X) begin
   v = h(v)
   v
 end
-@test is_permuted_equal(diagram, to_wiring_diagram(compose(f,g,h)), [2,3,1])
+@test diagram == to_wiring_diagram(compose(f,g,h))
 
 diagram = @parse_wiring_diagram C (x::X, y::Y) begin
   w, z = m(x, y)
@@ -102,8 +102,6 @@ test_roundtrip(otimes(f,h))
 test_roundtrip(compose(m,n))
 test_roundtrip(compose(l, braid(Y,X), m))
 test_roundtrip(compose(mcopy(X), otimes(f,f)))
-
-f = compose(f, mcopy(Y), otimes(g,g))
-@test is_permuted_equal(roundtrip(f), to_wiring_diagram(f), [2,3,1])
+test_roundtrip(compose(f, mcopy(Y), otimes(g,g)))
 
 end

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -25,7 +25,7 @@ junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,2))
 d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
 original = copy(d)
 junctioned = compose(junction_diagram(:A,1,2), to_wiring_diagram(otimes(f,f)))
-@test add_junctions!(d) == junctioned
+@test is_permuted_equal(add_junctions!(d), junctioned, [3,1,2])
 @test rem_junctions!(d) == original
 
 # Add junctions for merges.
@@ -38,7 +38,7 @@ junctioned = compose(junction_diagram(:A,2,1), to_wiring_diagram(f))
 d = to_wiring_diagram(compose(otimes(f,f), mmerge(B)))
 original = copy(d)
 junctioned = compose(to_wiring_diagram(otimes(f,f)), junction_diagram(:B,2,1))
-@test is_permuted_equal(add_junctions!(d), junctioned, [2,3,1])
+@test add_junctions!(d) == junctioned
 @test rem_junctions!(d) == original
 
 # Add junctions for deletions.

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -113,17 +113,17 @@ add_wires!(sub, Pair[
   (gv,1) => (hv,1),
   (hv,1) => (output_id(sub),1),
 ])
-d = WiringDiagram(A,D)
-fv = add_box!(d, f)
-subv = add_box!(d, sub)
-add_wires!(d, Pair[
-  (input_id(d),1) => (fv,1),
+d0 = WiringDiagram(A,D)
+fv = add_box!(d0, f)
+subv = add_box!(d0, sub)
+add_wires!(d0, Pair[
+  (input_id(d0),1) => (fv,1),
   (fv,1) => (subv,1),
-  (subv,1) => (output_id(d),1),
+  (subv,1) => (output_id(d0),1),
 ])
-@test boxes(d) == [ Box(f), sub ]
+@test boxes(d0) == [ Box(f), sub ]
 @test boxes(sub) == [ Box(g), Box(h) ]
-d = substitute!(d, subv)
+d = substitute(d0, subv)
 @test nboxes(d) == 3
 @test Set(boxes(d)) == Set([ Box(f), Box(g), Box(h) ])
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
@@ -147,8 +147,7 @@ add_wires!(d0, Pair[
   (hv,1) => (output_id(d),1)
 ])
 
-d = deepcopy(d0)
-d = encapsulate!(d, [fv,gv])
+d = encapsulate(d0, [fv,gv])
 @test nboxes(d) == 2
 @test sum(isa(b, WiringDiagram) for b in boxes(d)) == 1
 @test nwires(d) == 3
@@ -162,8 +161,7 @@ box_map = Dict(box(sub,v).value => v for v in box_ids(sub))
   (box_map[:g],1) => (output_id(sub),1),
 ]))
 
-d = deepcopy(d0)
-d = encapsulate!(d, [fv,gv], discard_boxes=true, value=:e)
+d = encapsulate(d0, [fv,gv], discard_boxes=true, value=:e)
 @test Set(boxes(d)) == Set([ Box(:e, [:A], [:C]), Box(h) ])
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
 @test Set(wires(d)) == Set(map(Wire, [
@@ -181,8 +179,7 @@ add_wires!(d0, Pair[
   (v1,1) => (output_id(d),1),
   (v2,1) => (output_id(d),1),
 ])
-d = deepcopy(d0)
-d = encapsulate!(d, [v1,v2])
+d = encapsulate(d0, [v1,v2])
 @test nboxes(d) == 1
 @test nwires(d) == 2
 sub = first(boxes(d))

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -103,6 +103,26 @@ rem_wires!(d, fv, gv)
 rem_wire!(d, (input_id(d),1) => (fv,1))
 @test wires(d) == [ Wire((gv,1) => (output_id(d),1)) ]
 
+# Induced subgraph.
+d = WiringDiagram(A,D)
+fv, gv, hv = add_box!(d, f), add_box!(d, g), add_box!(d, h)
+add_wires!(d, Pair[
+  (input_id(d),1) => (fv,1),
+  (fv,1) => (gv,1),
+  (gv,1) => (hv,1),
+  (hv,1) => (output_id(d),1),
+])
+sub = WiringDiagram(A, D)
+fv, gv = add_box!(sub, f), add_box!(sub, g)
+add_wires!(sub, Pair[
+  (input_id(sub),1) => (fv,1),
+  (fv,1) => (gv,1),
+])
+@test induced_subdiagram(d, [fv, gv]) == sub
+
+# Substitution and encapulsation
+################################
+
 # Substitution
 f, g, h = Hom(:f,A,B), Hom(:g,B,C), Hom(:h,C,D)
 sub = WiringDiagram(B,D)

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -123,7 +123,7 @@ add_wires!(d, Pair[
 ])
 @test boxes(d) == [ Box(f), sub ]
 @test boxes(sub) == [ Box(g), Box(h) ]
-substitute!(d, subv)
+d = substitute!(d, subv)
 @test nboxes(d) == 3
 @test Set(boxes(d)) == Set([ Box(f), Box(g), Box(h) ])
 box_map = Dict(box(d,v).value => v for v in box_ids(d))

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -148,7 +148,7 @@ add_wires!(d0, Pair[
 ])
 
 d = deepcopy(d0)
-encapsulate!(d, [fv,gv])
+d = encapsulate!(d, [fv,gv])
 @test nboxes(d) == 2
 @test sum(isa(b, WiringDiagram) for b in boxes(d)) == 1
 @test nwires(d) == 3
@@ -163,7 +163,7 @@ box_map = Dict(box(sub,v).value => v for v in box_ids(sub))
 ]))
 
 d = deepcopy(d0)
-encapsulate!(d, [fv,gv], discard_boxes=true, value=:e)
+d = encapsulate!(d, [fv,gv], discard_boxes=true, value=:e)
 @test Set(boxes(d)) == Set([ Box(:e, [:A], [:C]), Box(h) ])
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
 @test Set(wires(d)) == Set(map(Wire, [
@@ -182,7 +182,7 @@ add_wires!(d0, Pair[
   (v2,1) => (output_id(d),1),
 ])
 d = deepcopy(d0)
-encapsulate!(d, [v1,v2])
+d = encapsulate!(d, [v1,v2])
 @test nboxes(d) == 1
 @test nwires(d) == 2
 sub = first(boxes(d))


### PR DESCRIPTION
Resolves #39 and #55 by reimplementing `substitute!` (now non-mutating and called `substitute`) and `encapsulate!` (now non-mutating and called `encapsulate`). Also exposes `encapsulated_subdiagram` as an exported function and adds `induced_subdiagram` as a non-mutating alternative to `rem_boxes!`.