### PR TITLE
Wiring diagrams for self-dual compact closed categories

### DIFF
--- a/docs/literate/graphics/composejl_wiring_diagrams.jl
+++ b/docs/literate/graphics/composejl_wiring_diagrams.jl
@@ -49,7 +49,7 @@ to_composejl((braid(A,B) ⊗ id(C)) ⋅ (id(B) ⊗ braid(A,C) ⋅ (braid(B,C) �
 # ### Biproduct category
 
 A, B = Ob(FreeBiproductCategory, :A, :B)
-f, g = Hom(:f, A, B), Hom(:g, B, A)
+f = Hom(:f, A, B)
 
 to_composejl(mcopy(A))
 #-
@@ -62,7 +62,7 @@ to_composejl(mcopy(A)⋅(f⊗f)⋅mmerge(B))
 # The unit and co-unit of a compact closed category appear as caps and cups.
 
 A, B = Ob(FreeBicategoryRelations, :A, :B)
-f, g = Hom(:f, A, B), Hom(:g, B, A)
+f = Hom(:f, A, B)
 
 to_composejl(dunit(A))
 #-
@@ -80,6 +80,9 @@ to_composejl((dunit(A) ⊗ id(B)) ⋅ (id(A) ⊗ f ⊗ id(B)) ⋅ (id(A) ⊗ dco
 # [properties](http://giovineitalia.github.io/Compose.jl/latest/gallery/properties/).
 
 using Compose: fill, stroke
+
+A, B, = Ob(FreeSymmetricMonoidalCategory, :A, :B)
+f, g = Hom(:f, A, B), Hom(:g, B, A)
 
 to_composejl(f⋅g, box_props=[fill("lavender"), stroke("black")])
 
@@ -102,6 +105,10 @@ using Compose: draw, PGF
 
 pic = to_composejl(f⋅g, rounded_boxes=false)
 pgf = sprint() do io
-  draw(PGF(io, pic.width, pic.height, false, true, texfonts=true), pic.context)
+  pgf_backend = PGF(io, pic.width, pic.height,
+    false, # emit_on_finish
+    true,  # only_tikz
+    texfonts=true)
+  draw(pgf_backend, pic.context)
 end
 println(pgf)

--- a/docs/literate/graphics/composejl_wiring_diagrams.jl
+++ b/docs/literate/graphics/composejl_wiring_diagrams.jl
@@ -57,6 +57,23 @@ to_composejl(delete(A))
 #-
 to_composejl(mcopy(A)⋅(f⊗f)⋅mmerge(B))
 
+# ### Compact closed category
+
+# The unit and co-unit of a compact closed category appear as caps and cups.
+
+A, B = Ob(FreeBicategoryRelations, :A, :B)
+f, g = Hom(:f, A, B), Hom(:g, B, A)
+
+to_composejl(dunit(A))
+#-
+to_composejl(dcounit(A))
+
+# In a self-dual compact closed category, such as a bicategory of relations,
+# every morphism $f: A \to B$ has a transpose $f^\dagger: B \to A$ given by
+# bending wires:
+
+to_composejl((dunit(A) ⊗ id(B)) ⋅ (id(A) ⊗ f ⊗ id(B)) ⋅ (id(A) ⊗ dcounit(B)))
+
 # ## Custom styles
 
 # The visual appearance of wiring diagrams can be customized by passing Compose
@@ -84,4 +101,7 @@ to_composejl(f⋅g, box_props=[fill("lavender"), stroke("black")])
 using Compose: draw, PGF
 
 pic = to_composejl(f⋅g, rounded_boxes=false)
-draw(PGF(stdout, pic.width, pic.height), pic.context)
+pgf = sprint() do io
+  draw(PGF(io, pic.width, pic.height, false, true, texfonts=true), pic.context)
+end
+println(pgf)

--- a/docs/src/apis/wiring_diagrams.md
+++ b/docs/src/apis/wiring_diagrams.md
@@ -8,6 +8,7 @@ CurrentModule = Catlab.WiringDiagrams
 Modules = [
   WiringDiagramCore,
   WiringLayers,
+  AlgebraicWiringDiagrams,
   WiringDiagramAlgorithms,
   WiringDiagramSerialization,
   GraphMLWiringDiagrams,

--- a/src/graphics/ComposeWiringDiagrams.jl
+++ b/src/graphics/ComposeWiringDiagrams.jl
@@ -10,9 +10,9 @@ const C = Compose
 
 using ...WiringDiagrams
 using ..WiringDiagramLayouts
-using ..WiringDiagramLayouts: AbstractVector2D, Vector2D, BoxShape,
-  RectangleShape, JunctionShape, position, size, lower_corner, upper_corner,
-  normal, tangent, wire_points
+using ..WiringDiagramLayouts: AbstractVector2D, Vector2D,
+  BoxShape, RectangleShape, JunctionShape, NoShape,
+  position, size, lower_corner, upper_corner, normal, tangent, wire_points
 
 # Data types
 ############
@@ -141,6 +141,7 @@ end
 function render_box(::Val{JunctionShape}, ::Any, opts::ComposeOptions)
   C.compose(C.context(), C.circle(), opts.junction_props...)
 end
+render_box(::Val{NoShape}, ::Any, ::ComposeOptions) = C.context()
 
 # Compose.jl forms
 ##################

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -3,8 +3,6 @@
 module TikZWiringDiagrams
 export to_tikz
 
-using Match
-
 using ...Doctrines: ObExpr, HomExpr, dom, codom, head, args, compose, id
 using ...Syntax: GATExpr, show_latex
 using ...WiringDiagrams

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -4,8 +4,9 @@ This module provides a high-level functional and algebraic interface to wiring
 diagrams, built on top of the lower-level imperative interface.
 """
 module AlgebraicWiringDiagrams
-export Junction, dom, codom, id, compose, otimes, munit, braid, mcopy, delete,
-  mmerge, create, permute, ocompose, add_junctions!, rem_junctions!
+export dom, codom, id, compose, otimes, munit, braid, permute, mcopy, delete,
+  mmerge, create, dunit, dcounit, ocompose,
+  Junction, add_junctions, add_junctions!, rem_junctions
 
 using AutoHashEquals
 
@@ -194,8 +195,11 @@ end
 """ Add junction nodes to wiring diagram.
 
 Transforms from the implicit to the explicit representation of diagonals and
-codiagonals. This operation is inverse to `rem_junctions!`.
+codiagonals. This operation is inverse to `rem_junctions`.
 """
+function add_junctions(d::WiringDiagram)
+  add_junctions!(copy(d))
+end
 function add_junctions!(d::WiringDiagram)
   add_output_junctions!(d, input_id(d))
   add_input_junctions!(d, output_id(d))
@@ -235,12 +239,9 @@ end
 """ Remove junction nodes from wiring diagram.
 
 Transforms from the explicit to the implicit representation of diagonals and
-codiagonals. This operation is inverse to `add_junctions!`.
-
-Note: This function does not actually mutate its argument. However, this is
-subject to change in the future.
+codiagonals. This operation is inverse to `add_junctions`.
 """
-function rem_junctions!(d::WiringDiagram)
+function rem_junctions(d::WiringDiagram)
   junction_ids = filter(v -> box(d,v) isa Junction, box_ids(d))
   junction_diagrams = map(junction_ids) do v
     junction = box(d,v)::Junction

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -1,0 +1,253 @@
+""" Wiring diagrams as a symmetric monoidal category and as an operad.
+
+This module provides a high-level functional and algebraic interface to wiring
+diagrams, built on top of the lower-level imperative interface.
+"""
+module AlgebraicWiringDiagrams
+export Junction, dom, codom, id, compose, otimes, munit, braid, mcopy, delete,
+  mmerge, create, permute, ocompose, add_junctions!, rem_junctions!
+
+using AutoHashEquals
+
+using ...GAT, ...Syntax
+import ...Doctrines:
+  ObExpr, HomExpr, MonoidalCategoryWithBidiagonals, dom, codom, id, compose,
+  otimes, munit, braid, mcopy, delete, mmerge, create, dunit, dcounit
+using ..WiringDiagramCore, ..WiringLayers
+import ..WiringDiagramCore: Box, WiringDiagram, Ports,
+  input_ports, output_ports, add_box!
+
+# Data types
+############
+
+""" Junction node in a wiring diagram.
+
+Junction nodes are used to explicitly represent copies, merges, deletions,
+creations, caps, and cups.
+"""
+@auto_hash_equals struct Junction{Value} <: AbstractBox
+  value::Value
+  ninputs::Int
+  noutputs::Int
+end
+input_ports(junction::Junction) = repeat([junction.value], junction.ninputs)
+output_ports(junction::Junction) = repeat([junction.value], junction.noutputs)
+
+# Categorical interface
+#######################
+
+""" Create box for a morphism generator.
+"""
+function Box(expr::HomExpr{:generator})
+  Box(first(expr), collect_values(dom(expr)), collect_values(codom(expr)))
+end
+add_box!(f::WiringDiagram, expr::HomExpr) = add_box!(f, Box(expr))
+
+""" Create empty wiring diagram with given domain and codomain objects.
+"""
+function WiringDiagram(inputs::ObExpr, outputs::ObExpr)
+  WiringDiagram(Ports(inputs), Ports(outputs))
+end
+Ports(expr::ObExpr) = Ports(collect_values(expr))
+
+function collect_values(ob::ObExpr)::Vector
+  exprs = collect(ob)
+  @assert all(head(expr) == :generator for expr in exprs)
+  return map(first, exprs)
+end
+
+""" Wiring diagrams as a monoidal category with diagonals and codiagonals.
+"""
+@instance MonoidalCategoryWithBidiagonals(Ports, WiringDiagram) begin
+  dom(f::WiringDiagram) = Ports(f.input_ports)
+  codom(f::WiringDiagram) = Ports(f.output_ports)
+  
+  function id(A::Ports)
+    f = WiringDiagram(A, A)
+    add_wires!(f, ((input_id(f),i) => (output_id(f),i) for i in eachindex(A)))
+    return f
+  end
+  
+  function compose(f::WiringDiagram, g::WiringDiagram; unsubstituted::Bool=false)
+    if length(codom(f)) != length(dom(g))
+      # Check only that f and g have the same number of ports.
+      # The port types will be checked when the wires are added.
+      error("Incompatible domains $(codom(f)) and $(dom(g))")
+    end
+    h = WiringDiagram(dom(f), codom(g))
+    fv = add_box!(h, f)
+    gv = add_box!(h, g)
+    add_wires!(h, ((input_id(h),i) => (fv,i) for i in eachindex(dom(f))))
+    add_wires!(h, ((fv,i) => (gv,i) for i in eachindex(codom(f))))
+    add_wires!(h, ((gv,i) => (output_id(h),i) for i in eachindex(codom(g))))
+    unsubstituted ? h : substitute(h, [fv,gv])
+  end
+  
+  otimes(A::Ports, B::Ports) = Ports([A.ports; B.ports])
+  munit(::Type{Ports}) = Ports([])
+  
+  function otimes(f::WiringDiagram, g::WiringDiagram; unsubstituted::Bool=false)
+    h = WiringDiagram(otimes(dom(f),dom(g)), otimes(codom(f),codom(g)))
+    m, n = length(dom(f)), length(codom(f))
+    fv = add_box!(h, f)
+    gv = add_box!(h, g)
+    add_wires!(h, (input_id(h),i) => (fv,i) for i in eachindex(dom(f)))
+    add_wires!(h, (input_id(h),i+m) => (gv,i) for i in eachindex(dom(g)))
+    add_wires!(h, (fv,i) => (output_id(h),i) for i in eachindex(codom(f)))
+    add_wires!(h, (gv,i) => (output_id(h),i+n) for i in eachindex(codom(g)))
+    unsubstituted ? h : substitute(h, [fv,gv])
+  end
+  
+  function braid(A::Ports, B::Ports)
+    h = WiringDiagram(otimes(A,B), otimes(B,A))
+    m, n = length(A), length(B)
+    add_wires!(h, ((input_id(h),i) => (output_id(h),i+n) for i in 1:m))
+    add_wires!(h, ((input_id(h),i+m) => (output_id(h),i) for i in 1:n))
+    h
+  end
+
+  mcopy(A::Ports) = mcopy(A, 2)
+  mmerge(A::Ports) = mmerge(A, 2)
+  delete(A::Ports) = WiringDiagram(A, munit(Ports))
+  create(A::Ports) = WiringDiagram(munit(Ports), A)
+end
+
+# Unbiased variants of braiding (permutation), copying, and merging.
+
+function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
+  @assert length(A) == length(σ)
+  B = Ports([ A.ports[σ[i]] for i in eachindex(σ) ])
+  if inverse
+    f = WiringDiagram(B, A)
+    add_wires!(f, ((input_id(f),σ[i]) => (output_id(f),i) for i in eachindex(σ)))
+  else
+    f = WiringDiagram(A, B)
+    add_wires!(f, ((input_id(f),i) => (output_id(f),σ[i]) for i in eachindex(σ)))
+  end
+  return f
+end
+
+function mcopy(A::Ports, n::Int)::WiringDiagram
+  f = WiringDiagram(A, otimes([A for j in 1:n]))
+  m = length(A)
+  for j in 1:n
+    add_wires!(f, ((input_id(f),i) => (output_id(f),i+m*(j-1)) for i in 1:m))
+  end
+  return f
+end
+
+function mmerge(A::Ports, n::Int)::WiringDiagram
+  f = WiringDiagram(otimes([A for j in 1:n]), A)
+  m = length(A)
+  for j in 1:n
+    add_wires!(f, ((input_id(f),i+m*(j-1)) => (output_id(f),i) for i in 1:m))
+  end
+  return f
+end
+
+# Wiring diagrams as self-dual compact closed category.
+# FIXME: What about compact categories that are not self-dual?
+
+function dunit(A::Ports)
+  f = WiringDiagram(munit(Ports), otimes(A,A))
+  n = length(A)
+  for (i, port) in enumerate(A.ports)
+    v = add_box!(f, Junction(port, 0, 2))
+    add_wires!(f, ((v,1) => (output_id(f),i), (v,2) => (output_id(f),i+n)))
+  end
+  return f
+end
+
+function dcounit(A::Ports)
+  f = WiringDiagram(otimes(A,A), munit(Ports))
+  n = length(A)
+  for (i, port) in enumerate(A.ports)
+    v = add_box!(f, Junction(port, 2, 0))
+    add_wires!(f, ((input_id(f),i) => (v,1), (input_id(f),i+n) => (v,2)))
+  end
+  return f
+end
+
+# Operadic interface
+####################
+
+""" Operadic composition of wiring diagrams.
+
+This generic function has two different signatures, corresponding to the two
+standard definitions of an operad (Yau, 2018, Operads of Wiring Diagrams,
+Definitions 2.3 and 2.10).
+
+This operation is a simple wrapper around substitution (`substitute`).
+"""
+function ocompose(f::WiringDiagram, gs::Vector{WiringDiagram})
+  @assert length(gs) == nboxes(f)
+  substitute(f, box_ids(f), gs)
+end
+function ocompose(f::WiringDiagram, i::Int, g::WiringDiagram)
+  @assert 1 <= i <= nboxes(f)
+  substitute(f, box_ids(f)[i], g)
+end
+
+# Junctions
+###########
+
+""" Add junction nodes to wiring diagram.
+
+Transforms from the implicit to the explicit representation of diagonals and
+codiagonals. This operation is inverse to `rem_junctions!`.
+"""
+function add_junctions!(d::WiringDiagram)
+  add_output_junctions!(d, input_id(d))
+  add_input_junctions!(d, output_id(d))
+  for v in box_ids(d)
+    add_input_junctions!(d, v)
+    add_output_junctions!(d, v)
+  end
+  return d
+end
+function add_input_junctions!(d::WiringDiagram, v::Int)
+  for (port, port_value) in enumerate(input_ports(d, v))
+    wires = in_wires(d, v, port)
+    nwires = length(wires)
+    if nwires != 1
+      rem_wires!(d, wires)
+      jv = add_box!(d, Junction(port_value, nwires, 1))
+      add_wire!(d, Port(jv, OutputPort, 1) => Port(v, InputPort, port))
+      add_wires!(d, [ wire.source => Port(jv, InputPort, i)
+                      for (i, wire) in enumerate(wires) ])
+    end
+  end
+end
+function add_output_junctions!(d::WiringDiagram, v::Int)
+  for (port, port_value) in enumerate(output_ports(d, v))
+    wires = out_wires(d, v, port)
+    nwires = length(wires)
+    if nwires != 1
+      rem_wires!(d, wires)
+      jv = add_box!(d, Junction(port_value, 1, nwires))
+      add_wire!(d, Port(v, OutputPort, port) => Port(jv, InputPort, 1))
+      add_wires!(d, [ Port(jv, OutputPort, i) => wire.target
+                      for (i, wire) in enumerate(wires) ])
+    end
+  end
+end
+
+""" Remove junction nodes from wiring diagram.
+
+Transforms from the explicit to the implicit representation of diagonals and
+codiagonals. This operation is inverse to `add_junctions!`.
+
+Note: This function does not actually mutate its argument. However, this is
+subject to change in the future.
+"""
+function rem_junctions!(d::WiringDiagram)
+  junction_ids = filter(v -> box(d,v) isa Junction, box_ids(d))
+  junction_diagrams = map(junction_ids) do v
+    junction = box(d,v)::Junction
+    layer = complete_layer(junction.ninputs, junction.noutputs)
+    to_wiring_diagram(layer, input_ports(junction), output_ports(junction))
+  end
+  substitute(d, junction_ids, junction_diagrams)
+end
+
+end

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -192,19 +192,17 @@ mutable struct WiringDiagram <: AbstractBox
   value::Any
   input_ports::Vector
   output_ports::Vector
-  input_id::Int
-  output_id::Int
   
   function WiringDiagram(value::Any, input_ports::Vector, output_ports::Vector)
     graph = MetaDiGraph()
-    diagram = new(graph, value, input_ports, output_ports, 1, 2)
+    diagram = new(graph, value, input_ports, output_ports)
     add_vertices!(graph, 2)
     return diagram
   end
   function WiringDiagram(d::WiringDiagram)
     # Copy constructor for shallow copy.
     graph = copy(d.graph)
-    new(graph, d.value, d.input_ports, d.output_ports, d.input_id, d.output_id)
+    new(graph, d.value, d.input_ports, d.output_ports)
   end
 end
 
@@ -218,8 +216,8 @@ function WiringDiagram(inputs::Ports, outputs::Ports)
   WiringDiagram(inputs.ports, outputs.ports)
 end
 
-input_id(diagram::WiringDiagram) = diagram.input_id
-output_id(diagram::WiringDiagram) = diagram.output_id
+input_id(::WiringDiagram) = 1
+output_id(::WiringDiagram) = 2
 
 """ Check equality of wiring diagrams.
 
@@ -230,7 +228,6 @@ See also: `is_permuted_equal`
 """
 function Base.:(==)(d1::WiringDiagram, d2::WiringDiagram)
   (input_ports(d1) == input_ports(d2) && output_ports(d1) == output_ports(d2) &&
-   input_id(d1) == input_id(d2) && output_id(d1) == output_id(d2) &&
    d1.value == d2.value && graph(d1) == graph(d2) &&
    boxes(d1) == boxes(d2) && sort!(wires(d1)) == sort!(wires(d2)))
 end

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -8,15 +8,12 @@ literature calls "directed graphs with ports" or more simply "port graphs". The
 main difference is that a wiring diagram has an "outer box": a wiring diagram
 has its own ports that can be connected to the ports of its boxes.
 
-This module offers a generic data structure for wiring diagrams. Arbitrary data
-can be attached to the boxes, ports, and wires of a wiring diagram. There is a
-low-level interface for direct manipulation of boxes and wires and a high-level
-interface based on the theory of symmetric monoidal categories. 
-
-The wiring diagrams in this module are "abstract" in the sense that they cannot
-be directly rendered as raster or vector graphics. However, they form a useful
-intermediate representation that can be straightforwardly serialized to and from
-GraphML or translated into Graphviz or other declarative diagram languages.
+This module provides a generic data structure for wiring diagrams. Arbitrary
+data can be attached to the boxes, ports, and wires of a wiring diagram. The
+diagrams are "abstract" in the sense that they cannot be directly rendered as
+raster or vector graphics. However, they form a useful intermediate
+representation that can be serialized to and from GraphML or translated into
+Graphviz or other declarative diagram languages.
 """
 module WiringDiagramCore
 export AbstractBox, Box, WiringDiagram, Wire, Ports, PortValueError, Port,
@@ -26,19 +23,12 @@ export AbstractBox, Box, WiringDiagram, Wire, Ports, PortValueError, Port,
   rem_wire!, rem_wires!, validate_ports,
   all_neighbors, neighbors, outneighbors, inneighbors, in_wires, out_wires,
   singleton_diagram, induced_subdiagram, encapsulated_subdiagram,
-  substitute, encapsulate,
-  dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create,
-  ocompose, permute, is_permuted_equal
+  substitute, encapsulate, is_permuted_equal
 
 using Compat
 using AutoHashEquals
 using LightGraphs, MetaGraphs
 import LightGraphs: all_neighbors, neighbors, outneighbors, inneighbors
-
-using ...GAT, ...Syntax
-import ...Doctrines:
-  CategoryExpr, ObExpr, HomExpr, MonoidalCategoryWithBidiagonals,
-  dom, codom, id, compose, otimes, munit, braid, mcopy, delete, mmerge, create
 
 # Data types
 ############
@@ -295,8 +285,8 @@ function Base.show(io::IO, diagram::WiringDiagram)
   print(io, ")")
 end
 
-# Low-level graph interface
-###########################
+# Imperative interface
+######################
 
 # Basic accessors.
 
@@ -545,10 +535,8 @@ function induced_subdiagram(d::WiringDiagram, vs::Vector{Int})
   return sub
 end
 
-# Substitution and encapulsation
-################################
-
-# Substition.
+# Substitution
+##############
 
 """ Substitute wiring diagrams for boxes.
 
@@ -667,7 +655,8 @@ end
 
 default_merge_wire_values(::Any, middle::Any, ::Any) = middle
 
-# Encapsulation.
+# Encapsulation
+###############
 
 """ Encapsulate multiple boxes within a single sub-diagram.
 
@@ -807,135 +796,6 @@ function encapsulated_subdiagram(d::WiringDiagram, vs::Vector{Int};
     result.input_ports, result.output_ports = inputs, outputs
   end
   (result, port_map)
-end
-
-# High-level categorical interface
-##################################
-
-""" Create box for a morphism generator.
-"""
-function Box(expr::HomExpr{:generator})
-  Box(first(expr), collect_values(dom(expr)), collect_values(codom(expr)))
-end
-add_box!(f::WiringDiagram, expr::HomExpr) = add_box!(f, Box(expr))
-
-""" Create empty wiring diagram with given domain and codomain objects.
-"""
-function WiringDiagram(inputs::ObExpr, outputs::ObExpr)
-  WiringDiagram(Ports(inputs), Ports(outputs))
-end
-Ports(expr::ObExpr) = Ports(collect_values(expr))
-
-""" Wiring diagrams as a monoidal category with diagonals and codiagonals.
-"""
-@instance MonoidalCategoryWithBidiagonals(Ports, WiringDiagram) begin
-  dom(f::WiringDiagram) = Ports(f.input_ports)
-  codom(f::WiringDiagram) = Ports(f.output_ports)
-  
-  function id(A::Ports)
-    f = WiringDiagram(A, A)
-    add_wires!(f, ((input_id(f),i) => (output_id(f),i) for i in eachindex(A)))
-    return f
-  end
-  
-  function compose(f::WiringDiagram, g::WiringDiagram; unsubstituted::Bool=false)
-    if length(codom(f)) != length(dom(g))
-      # Check only that f and g have the same number of ports.
-      # The port types will be checked when the wires are added.
-      error("Incompatible domains $(codom(f)) and $(dom(g))")
-    end
-    h = WiringDiagram(dom(f), codom(g))
-    fv = add_box!(h, f)
-    gv = add_box!(h, g)
-    add_wires!(h, ((input_id(h),i) => (fv,i) for i in eachindex(dom(f))))
-    add_wires!(h, ((fv,i) => (gv,i) for i in eachindex(codom(f))))
-    add_wires!(h, ((gv,i) => (output_id(h),i) for i in eachindex(codom(g))))
-    unsubstituted ? h : substitute(h, [fv,gv])
-  end
-  
-  otimes(A::Ports, B::Ports) = Ports([A.ports; B.ports])
-  munit(::Type{Ports}) = Ports([])
-  
-  function otimes(f::WiringDiagram, g::WiringDiagram; unsubstituted::Bool=false)
-    h = WiringDiagram(otimes(dom(f),dom(g)), otimes(codom(f),codom(g)))
-    m, n = length(dom(f)), length(codom(f))
-    fv = add_box!(h, f)
-    gv = add_box!(h, g)
-    add_wires!(h, (input_id(h),i) => (fv,i) for i in eachindex(dom(f)))
-    add_wires!(h, (input_id(h),i+m) => (gv,i) for i in eachindex(dom(g)))
-    add_wires!(h, (fv,i) => (output_id(h),i) for i in eachindex(codom(f)))
-    add_wires!(h, (gv,i) => (output_id(h),i+n) for i in eachindex(codom(g)))
-    unsubstituted ? h : substitute(h, [fv,gv])
-  end
-  
-  function braid(A::Ports, B::Ports)
-    h = WiringDiagram(otimes(A,B), otimes(B,A))
-    m, n = length(A), length(B)
-    add_wires!(h, ((input_id(h),i) => (output_id(h),i+n) for i in 1:m))
-    add_wires!(h, ((input_id(h),i+m) => (output_id(h),i) for i in 1:n))
-    h
-  end
-
-  mcopy(A::Ports) = mcopy(A, 2)
-  mmerge(A::Ports) = mmerge(A, 2)
-  delete(A::Ports) = WiringDiagram(A, munit(Ports))
-  create(A::Ports) = WiringDiagram(munit(Ports), A)
-end
-
-# Unbiased variants of braiding (permutation), copying, and merging.
-
-function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
-  @assert length(A) == length(σ)
-  B = Ports([ A.ports[σ[i]] for i in eachindex(σ) ])
-  if inverse
-    f = WiringDiagram(B, A)
-    add_wires!(f, ((input_id(f),σ[i]) => (output_id(f),i) for i in eachindex(σ)))
-  else
-    f = WiringDiagram(A, B)
-    add_wires!(f, ((input_id(f),i) => (output_id(f),σ[i]) for i in eachindex(σ)))
-  end
-  return f
-end
-
-function mcopy(A::Ports, n::Int)::WiringDiagram
-  f = WiringDiagram(A, otimes([A for j in 1:n]))
-  m = length(A)
-  for j in 1:n
-    add_wires!(f, ((input_id(f),i) => (output_id(f),i+m*(j-1)) for i in 1:m))
-  end
-  return f
-end
-
-function mmerge(A::Ports, n::Int)::WiringDiagram
-  f = WiringDiagram(otimes([A for j in 1:n]), A)
-  m = length(A)
-  for j in 1:n
-    add_wires!(f, ((input_id(f),i+m*(j-1)) => (output_id(f),i) for i in 1:m))
-  end
-  return f
-end
-
-""" Operadic composition of wiring diagrams.
-
-This generic function has two different signatures, corresponding to the two
-standard definitions of an operad (Yau, 2018, Operads of Wiring Diagrams,
-Definitions 2.3 and 2.10).
-
-This operation is a simple wrapper around substitution (`substitute`).
-"""
-function ocompose(f::WiringDiagram, gs::Vector{WiringDiagram})
-  @assert length(gs) == nboxes(f)
-  substitute(f, box_ids(f), gs)
-end
-function ocompose(f::WiringDiagram, i::Int, g::WiringDiagram)
-  @assert 1 <= i <= nboxes(f)
-  substitute(f, box_ids(f)[i], g)
-end
-
-function collect_values(ob::ObExpr)::Vector
-  exprs = collect(ob)
-  @assert all(head(expr) == :generator for expr in exprs)
-  return map(first, exprs)
 end
 
 end

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -826,7 +826,7 @@ function WiringDiagram(inputs::ObExpr, outputs::ObExpr)
 end
 Ports(expr::ObExpr) = Ports(collect_values(expr))
 
-""" Wiring diagram as *monoidal category with diagonals and codiagonals*.
+""" Wiring diagrams as a monoidal category with diagonals and codiagonals.
 """
 @instance MonoidalCategoryWithBidiagonals(Ports, WiringDiagram) begin
   dom(f::WiringDiagram) = Ports(f.input_ports)
@@ -882,18 +882,19 @@ Ports(expr::ObExpr) = Ports(collect_values(expr))
   create(A::Ports) = WiringDiagram(munit(Ports), A)
 end
 
+# Unbiased variants of braiding (permutation), copying, and merging.
+
 function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
   @assert length(A) == length(σ)
   B = Ports([ A.ports[σ[i]] for i in eachindex(σ) ])
   if inverse
     f = WiringDiagram(B, A)
     add_wires!(f, ((input_id(f),σ[i]) => (output_id(f),i) for i in eachindex(σ)))
-    return f
   else
     f = WiringDiagram(A, B)
     add_wires!(f, ((input_id(f),i) => (output_id(f),σ[i]) for i in eachindex(σ)))
-    return f
   end
+  return f
 end
 
 function mcopy(A::Ports, n::Int)::WiringDiagram

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -50,10 +50,9 @@ function to_hom_expr(Ob::Type, Hom::Type, d::WiringDiagram)
   
   # Step 0: Reduction: Add junction nodes to ensure any wiring layer between
   # two boxes is a permutation.
-  d = copy(d)
-  add_junctions!(d)
+  d = add_junctions(d)
   
-  # Special case: no boxes.
+  # Dispatch special case: no boxes.
   if nboxes(d) == 0
     return hom_expr_between(Ob, d, input_id(d), output_id(d))
   end

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -18,10 +18,9 @@ using LightGraphs
 using ...Syntax
 using ...Doctrines: id, compose, otimes, munit, mcopy, mmerge, create, delete
 using ...Doctrines.Permutations
-using ..WiringDiagramCore, ..WiringLayers
+using ..WiringDiagramCore, ..WiringLayers, ..AlgebraicWiringDiagrams
 import ..WiringLayers: to_wiring_diagram
-using ..WiringDiagramAlgorithms: Junction, add_junctions!,
-  crossing_minimization_by_sort
+using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 
 # Expression -> Diagram
 #######################

--- a/src/wiring_diagrams/Layers.jl
+++ b/src/wiring_diagrams/Layers.jl
@@ -51,8 +51,8 @@ Object in the category of wiring layers.
   n::Int
 end
 
-# Low-level graph interface
-###########################
+# Imperative interface
+######################
 
 # Constructors.
 
@@ -143,8 +143,8 @@ function check_wire_bounds(f::WiringLayer, wire)
   end
 end
 
-# High-level categorical interface
-##################################
+# Categorical interface
+#######################
 
 NLayer(ob::ObExpr) = NLayer(ndims(ob))
 WiringLayer(inputs::ObExpr, outputs::ObExpr) =

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -4,6 +4,7 @@ using Reexport
 
 include("Core.jl")
 include("Layers.jl")
+include("Algebraic.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("Serialization.jl")
@@ -12,12 +13,12 @@ include("JSON.jl")
 
 @reexport using .WiringDiagramCore
 @reexport using .WiringLayers
+@reexport using .AlgebraicWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 
 using .WiringDiagramSerialization
 export convert_from_graph_data, convert_to_graph_data
-
 @reexport using .GraphMLWiringDiagrams
 @reexport using .JSONWiringDiagrams
 

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -160,47 +160,40 @@ junction_diagram(args...) = singleton_diagram(Junction(args...))
 
 # Add junctions for copies.
 d = to_wiring_diagram(compose(f, mcopy(B)))
-original = copy(d)
 junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,2))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
+@test add_junctions(d) == junctioned
+@test rem_junctions(junctioned) == d
 
 d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
-original = copy(d)
 junctioned = compose(junction_diagram(:A,1,2), to_wiring_diagram(otimes(f,f)))
-@test is_permuted_equal(add_junctions!(d), junctioned, [3,1,2])
-@test rem_junctions!(d) == original
+@test is_permuted_equal(add_junctions(d), junctioned, [3,1,2])
+@test rem_junctions(junctioned) == d
 
 # Add junctions for merges.
 d = to_wiring_diagram(compose(mmerge(A), f))
-original = copy(d)
 junctioned = compose(junction_diagram(:A,2,1), to_wiring_diagram(f))
-@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
-@test rem_junctions!(d) == original
+@test is_permuted_equal(add_junctions(d), junctioned, [2,1])
+@test rem_junctions(junctioned) == d
 
 d = to_wiring_diagram(compose(otimes(f,f), mmerge(B)))
-original = copy(d)
 junctioned = compose(to_wiring_diagram(otimes(f,f)), junction_diagram(:B,2,1))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
+@test add_junctions(d) == junctioned
+@test rem_junctions(junctioned) == d
 
 # Add junctions for deletions.
 d = to_wiring_diagram(compose(f, delete(B)))
-original = copy(d)
 junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,0))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
+@test add_junctions(d) == junctioned
+@test rem_junctions(junctioned) == d
 
 # Add junctions for creations.
 d = to_wiring_diagram(compose(create(A), f))
-original = copy(d)
 junctioned = compose(junction_diagram(:A,0,1), to_wiring_diagram(f))
-@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
-@test rem_junctions!(d) == original
+@test is_permuted_equal(add_junctions(d), junctioned, [2,1])
+@test rem_junctions(junctioned) == d
 
 # Add junctions for copies, merges, deletions, and creations, all at once.
 d = to_wiring_diagram(compose(create(A),f,mcopy(B),mmerge(B),g,delete(C)))
-original = copy(d)
 junctioned = compose(
   junction_diagram(:A,0,1),
   to_wiring_diagram(f),
@@ -209,10 +202,10 @@ junctioned = compose(
   to_wiring_diagram(g),
   junction_diagram(:C,1,0)
 )
-d = add_junctions!(d)
+actual = add_junctions(d)
 # XXX: An isomorphism test would be more convenient.
-perm = [ findfirst([b] .== boxes(d)) for b in boxes(junctioned) ]
-@test is_permuted_equal(d, junctioned, perm)
-@test rem_junctions!(d) == original
+perm = [ findfirst([b] .== boxes(actual)) for b in boxes(junctioned) ]
+@test is_permuted_equal(actual, junctioned, perm)
+@test rem_junctions(junctioned) == d
 
 end

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -6,15 +6,11 @@ using Catlab.Doctrines, Catlab.WiringDiagrams
 # Categorical interface
 #######################
 
-A, B, C, D = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C, :D)
-f = Hom(:f, A, B)
-g = Hom(:g, B, C)
-h = Hom(:h, C, D)
-
 # Category
 #---------
 
 # Generators
+A, B = Ob(FreeSymmetricMonoidalCategory, :A, :B)
 f = singleton_diagram(Box(Hom(:f,A,B)))
 g = singleton_diagram(Box(Hom(:g,B,A)))
 @test nboxes(f) == 1
@@ -152,54 +148,57 @@ d = compose(f(1),f(2))
 # Junctions
 ###########
 
-A, B, C, D = Ob(FreeBiproductCategory, :A, :B, :C, :D)
-f = Hom(:f, A, B)
-g = Hom(:g, B, C)
+A, B, C = [ Ports([sym]) for sym in [:A, :B, :C] ]
+f = singleton_diagram(Box(:f, [:A], [:B]))
+g = singleton_diagram(Box(:g, [:B], [:C]))
 
 junction_diagram(args...) = singleton_diagram(Junction(args...))
 
-# Add junctions for copies.
-d = to_wiring_diagram(compose(f, mcopy(B)))
-junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,2))
+# Add and remove junctions
+#-------------------------
+
+# Copies.
+d = compose(f, mcopy(B))
+junctioned = compose(f, junction_diagram(:B,1,2))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
-d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
-junctioned = compose(junction_diagram(:A,1,2), to_wiring_diagram(otimes(f,f)))
+d = compose(mcopy(A), otimes(f,f))
+junctioned = compose(junction_diagram(:A,1,2), otimes(f,f))
 @test is_permuted_equal(add_junctions(d), junctioned, [3,1,2])
 @test rem_junctions(junctioned) == d
 
-# Add junctions for merges.
-d = to_wiring_diagram(compose(mmerge(A), f))
-junctioned = compose(junction_diagram(:A,2,1), to_wiring_diagram(f))
+# Merges.
+d = compose(mmerge(A), f)
+junctioned = compose(junction_diagram(:A,2,1), f)
 @test is_permuted_equal(add_junctions(d), junctioned, [2,1])
 @test rem_junctions(junctioned) == d
 
-d = to_wiring_diagram(compose(otimes(f,f), mmerge(B)))
-junctioned = compose(to_wiring_diagram(otimes(f,f)), junction_diagram(:B,2,1))
+d = compose(otimes(f,f), mmerge(B))
+junctioned = compose(otimes(f,f), junction_diagram(:B,2,1))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
-# Add junctions for deletions.
-d = to_wiring_diagram(compose(f, delete(B)))
-junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,0))
+# Deletions.
+d = compose(f, delete(B))
+junctioned = compose(f, junction_diagram(:B,1,0))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
-# Add junctions for creations.
-d = to_wiring_diagram(compose(create(A), f))
-junctioned = compose(junction_diagram(:A,0,1), to_wiring_diagram(f))
+# Creations.
+d = compose(create(A), f)
+junctioned = compose(junction_diagram(:A,0,1), f)
 @test is_permuted_equal(add_junctions(d), junctioned, [2,1])
 @test rem_junctions(junctioned) == d
 
-# Add junctions for copies, merges, deletions, and creations, all at once.
-d = to_wiring_diagram(compose(create(A),f,mcopy(B),mmerge(B),g,delete(C)))
+# Copies, merges, deletions, and creations, all at once.
+d = compose(create(A), f, mcopy(B), mmerge(B), g, delete(C))
 junctioned = compose(
   junction_diagram(:A,0,1),
-  to_wiring_diagram(f),
+  f,
   junction_diagram(:B,1,2),
   junction_diagram(:B,2,1),
-  to_wiring_diagram(g),
+  g,
   junction_diagram(:C,1,0)
 )
 actual = add_junctions(d)

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -1,0 +1,218 @@
+module TestAlgebraicWiringDiagrams
+using Test
+
+using Catlab.Doctrines, Catlab.WiringDiagrams
+
+# Categorical interface
+#######################
+
+A, B, C, D = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C, :D)
+f = Hom(:f, A, B)
+g = Hom(:g, B, C)
+h = Hom(:h, C, D)
+
+# Category
+#---------
+
+# Generators
+f = singleton_diagram(Box(Hom(:f,A,B)))
+g = singleton_diagram(Box(Hom(:g,B,A)))
+@test nboxes(f) == 1
+@test boxes(f) == [ Box(Hom(:f,A,B)) ]
+@test nwires(f) == 2
+
+# Composition
+@test nboxes(compose(f,g)) == 2
+@test boxes(compose(f,g)) == [ Box(Hom(:f,A,B)), Box(Hom(:g,B,A)) ]
+@test nwires(compose(f,g)) == 3
+
+# Domains and codomains
+@test dom(f) == Ports([:A])
+@test codom(f) == Ports([:B])
+@test dom(compose(f,g)) == Ports([:A])
+@test codom(compose(f,g)) == Ports([:A])
+@test_throws Exception compose(f,f)
+
+# Associativity
+@test compose(compose(f,g),f) == compose(f,compose(g,f))
+
+# Identity
+@test compose(id(dom(f)), f) == f
+@test compose(f, id(codom(f))) == f
+
+# Symmetric monoidal category
+#----------------------------
+
+# Domains and codomains
+@test dom(otimes(f,g)) == otimes(dom(f),dom(g))
+@test codom(otimes(f,g)) == otimes(codom(f),codom(g))
+
+# Associativity and unit
+X, Y = Ports([:A,:B]), Ports([:C,:D])
+I = munit(Ports)
+@test otimes(X,I) == X
+@test otimes(I,X) == X
+@test otimes(otimes(X,Y),X) == otimes(X,otimes(Y,X))
+@test otimes(otimes(f,g),f) == otimes(f,otimes(g,f))
+
+# Braiding
+@test compose(braid(X,Y),braid(Y,X)) == id(otimes(X,Y))
+
+# Permutations
+W = otimes(X,Y)
+@test permute(W, [1,2,3,4]) == id(W)
+@test permute(W, [1,2,3,4], inverse=true) == id(W)
+@test permute(W, [3,4,1,2]) == braid(X,Y)
+@test permute(W, [3,4,1,2], inverse=true) == braid(Y,X)
+@test_throws AssertionError permute(W, [1,2])
+
+# Diagonals
+#----------
+
+# Basic composition
+d = WiringDiagram(dom(f), otimes(codom(f),codom(f)))
+fv1 = add_box!(d, first(boxes(f)))
+fv2 = add_box!(d, first(boxes(f)))
+add_wires!(d, [
+  (input_id(d),1) => (fv1,1),
+  (input_id(d),1) => (fv2,1),
+  (fv1,1) => (output_id(d),1),
+  (fv2,1) => (output_id(d),2),
+])
+@test compose(mcopy(dom(f)), otimes(f,f)) == d
+
+# Domains and codomains
+@test dom(mcopy(Ports([:A]))) == Ports([:A])
+@test codom(mcopy(Ports([:A]))) == Ports([:A,:A])
+@test dom(mcopy(Ports([:A,:B]),3)) == Ports([:A,:B])
+@test codom(mcopy(Ports([:A,:B]),3)) == Ports([:A,:B,:A,:B,:A,:B])
+
+# Associativity
+X = Ports([:A])
+@test compose(mcopy(X), otimes(id(X),mcopy(X))) == mcopy(X,3)
+@test compose(mcopy(X), otimes(mcopy(X),id(X))) == mcopy(X,3)
+
+# Commutativity
+@test compose(mcopy(X), braid(X,X)) == mcopy(X)
+
+# Unit
+@test compose(mcopy(X), otimes(id(X),delete(X))) == id(X)
+
+# Codiagonals
+#------------
+
+# Domains and codomains
+@test dom(mmerge(Ports([:A]))) == Ports([:A,:A])
+@test codom(mmerge(Ports([:A]))) == Ports([:A])
+@test dom(mmerge(Ports([:A,:B]),3)) == Ports([:A,:B,:A,:B,:A,:B])
+@test codom(mmerge(Ports([:A,:B]),3)) == Ports([:A,:B])
+
+# Associativity
+X = Ports([:A])
+@test compose(otimes(id(X),mmerge(X)), mmerge(X)) == mmerge(X,3)
+@test compose(otimes(mmerge(X),id(X)), mmerge(X)) == mmerge(X,3)
+
+# Commutativity
+@test compose(braid(X,X), mmerge(X)) == mmerge(X)
+
+# Unit
+@test compose(otimes(id(X),create(X)), mmerge(X)) == id(X)
+
+# Operadic interface
+####################
+
+f, g, h = map([:f, :g, :h]) do sym
+  (i::Int) -> singleton_diagram(Box(Hom(Symbol("$sym$i"), A, A)))
+end
+
+# Identity
+d = compose(f(1),f(2))
+@test ocompose(g(1), 1, d) == d
+@test ocompose(g(1), [d]) == d
+@test ocompose(d, [f(1),f(2)]) == d
+@test ocompose(d, 1, f(1)) == d
+@test ocompose(d, 2, f(2)) == d
+
+# Associativity
+@test ocompose(compose(f(1),f(2)), [
+  ocompose(compose(g(1),g(2)), [compose(h(1),h(2)), compose(h(3),h(4))]),
+  ocompose(compose(g(3),g(4)), [compose(h(5),h(6)), compose(h(7),h(8))])
+]) == ocompose(
+  ocompose(compose(f(1),f(2)), [compose(g(1),g(2)), compose(g(3),g(4))]),
+  [compose(h(1),h(2)), compose(h(3),h(4)), compose(h(5),h(6)), compose(h(7),h(8))]
+)
+@test ocompose(
+  ocompose(compose(f(1),f(2)), 1, compose(g(1),g(2))),
+  3, compose(g(3),g(4))
+) == ocompose(
+  ocompose(compose(f(1),f(2)), 2, compose(g(3),g(4))),
+  1, compose(g(1),g(2))
+)
+
+# Junctions
+###########
+
+A, B, C, D = Ob(FreeBiproductCategory, :A, :B, :C, :D)
+f = Hom(:f, A, B)
+g = Hom(:g, B, C)
+
+junction_diagram(args...) = singleton_diagram(Junction(args...))
+
+# Add junctions for copies.
+d = to_wiring_diagram(compose(f, mcopy(B)))
+original = copy(d)
+junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,2))
+@test add_junctions!(d) == junctioned
+@test rem_junctions!(d) == original
+
+d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
+original = copy(d)
+junctioned = compose(junction_diagram(:A,1,2), to_wiring_diagram(otimes(f,f)))
+@test is_permuted_equal(add_junctions!(d), junctioned, [3,1,2])
+@test rem_junctions!(d) == original
+
+# Add junctions for merges.
+d = to_wiring_diagram(compose(mmerge(A), f))
+original = copy(d)
+junctioned = compose(junction_diagram(:A,2,1), to_wiring_diagram(f))
+@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
+@test rem_junctions!(d) == original
+
+d = to_wiring_diagram(compose(otimes(f,f), mmerge(B)))
+original = copy(d)
+junctioned = compose(to_wiring_diagram(otimes(f,f)), junction_diagram(:B,2,1))
+@test add_junctions!(d) == junctioned
+@test rem_junctions!(d) == original
+
+# Add junctions for deletions.
+d = to_wiring_diagram(compose(f, delete(B)))
+original = copy(d)
+junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,0))
+@test add_junctions!(d) == junctioned
+@test rem_junctions!(d) == original
+
+# Add junctions for creations.
+d = to_wiring_diagram(compose(create(A), f))
+original = copy(d)
+junctioned = compose(junction_diagram(:A,0,1), to_wiring_diagram(f))
+@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
+@test rem_junctions!(d) == original
+
+# Add junctions for copies, merges, deletions, and creations, all at once.
+d = to_wiring_diagram(compose(create(A),f,mcopy(B),mmerge(B),g,delete(C)))
+original = copy(d)
+junctioned = compose(
+  junction_diagram(:A,0,1),
+  to_wiring_diagram(f),
+  junction_diagram(:B,1,2),
+  junction_diagram(:B,2,1),
+  to_wiring_diagram(g),
+  junction_diagram(:C,1,0)
+)
+d = add_junctions!(d)
+# XXX: An isomorphism test would be more convenient.
+perm = [ findfirst([b] .== boxes(d)) for b in boxes(junctioned) ]
+@test is_permuted_equal(d, junctioned, perm)
+@test rem_junctions!(d) == original
+
+end

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -10,8 +10,8 @@ f = Hom(:f, A, B)
 g = Hom(:g, B, C)
 h = Hom(:h, C, D)
 
-# Diagonals and codiagonals
-###########################
+# Junctions
+###########
 
 junction_diagram(args...) = singleton_diagram(Junction(args...))
 
@@ -71,6 +71,9 @@ d = add_junctions!(d)
 perm = [ findfirst([b] .== boxes(d)) for b in boxes(junctioned) ]
 @test is_permuted_equal(d, junctioned, perm)
 @test rem_junctions!(d) == original
+
+# Normalization
+###############
 
 # Normalize copies.
 d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -1,79 +1,16 @@
 module TestWiringDiagramAlgorithms
 
 using Test
-using Catlab.Doctrines
-using Catlab.WiringDiagrams
-
-A, B, C, D = Ob(FreeBiproductCategory, :A, :B, :C, :D)
-I = munit(FreeBiproductCategory.Ob)
-f = Hom(:f, A, B)
-g = Hom(:g, B, C)
-h = Hom(:h, C, D)
-
-# Junctions
-###########
-
-junction_diagram(args...) = singleton_diagram(Junction(args...))
-
-# Add junctions for copies.
-d = to_wiring_diagram(compose(f, mcopy(B)))
-original = copy(d)
-junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,2))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
-
-d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
-original = copy(d)
-junctioned = compose(junction_diagram(:A,1,2), to_wiring_diagram(otimes(f,f)))
-@test is_permuted_equal(add_junctions!(d), junctioned, [3,1,2])
-@test rem_junctions!(d) == original
-
-# Add junctions for merges.
-d = to_wiring_diagram(compose(mmerge(A), f))
-original = copy(d)
-junctioned = compose(junction_diagram(:A,2,1), to_wiring_diagram(f))
-@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
-@test rem_junctions!(d) == original
-
-d = to_wiring_diagram(compose(otimes(f,f), mmerge(B)))
-original = copy(d)
-junctioned = compose(to_wiring_diagram(otimes(f,f)), junction_diagram(:B,2,1))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
-
-# Add junctions for deletions.
-d = to_wiring_diagram(compose(f, delete(B)))
-original = copy(d)
-junctioned = compose(to_wiring_diagram(f), junction_diagram(:B,1,0))
-@test add_junctions!(d) == junctioned
-@test rem_junctions!(d) == original
-
-# Add junctions for creations.
-d = to_wiring_diagram(compose(create(A), f))
-original = copy(d)
-junctioned = compose(junction_diagram(:A,0,1), to_wiring_diagram(f))
-@test is_permuted_equal(add_junctions!(d), junctioned, [2,1])
-@test rem_junctions!(d) == original
-
-# Add junctions for copies, merges, deletions, and creations, all at once.
-d = to_wiring_diagram(compose(create(A),f,mcopy(B),mmerge(B),g,delete(C)))
-original = copy(d)
-junctioned = compose(
-  junction_diagram(:A,0,1),
-  to_wiring_diagram(f),
-  junction_diagram(:B,1,2),
-  junction_diagram(:B,2,1),
-  to_wiring_diagram(g),
-  junction_diagram(:C,1,0)
-)
-d = add_junctions!(d)
-# XXX: An isomorphism test would be more convenient.
-perm = [ findfirst([b] .== boxes(d)) for b in boxes(junctioned) ]
-@test is_permuted_equal(d, junctioned, perm)
-@test rem_junctions!(d) == original
+using Catlab.Doctrines, Catlab.WiringDiagrams
 
 # Normalization
 ###############
+
+A, B, C, D = Ob(FreeCartesianCategory, :A, :B, :C, :D)
+I = munit(FreeCartesianCategory.Ob)
+f = Hom(:f, A, B)
+g = Hom(:g, B, C)
+h = Hom(:h, C, D)
 
 # Normalize copies.
 d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -8,6 +8,10 @@ end
   include("Layers.jl")
 end
 
+@testset "Algebraic" begin
+  include("Algebraic.jl")
+end
+
 @testset "Algorithms" begin
   include("Algorithms.jl")
 end


### PR DESCRIPTION
The units and counits are represented using junction nodes. Unlike the cases of diagonals or codiagonals, an implicit representation using only wires is not possible because it would require wires into output ports and wires out of input ports, breaking the important assumption for directed wiring diagrams that wires go from output ports to input ports.