### PR TITLE
Rewrite TikZ wiring diagrams to use backend-agnostic layout

### DIFF
--- a/docs/literate/graphics/tikz_wiring_diagrams.jl
+++ b/docs/literate/graphics/tikz_wiring_diagrams.jl
@@ -3,11 +3,12 @@
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/graphics/tikz_wiring_diagrams.ipynb)
 #
 # Catlab can draw morphism expressions as TikZ pictures. To use this feature,
-# you must import the [TikzPictures.jl](https://github.com/sisl/TikzPictures.jl)
-# package before loading `Catlab.Graphics`.
+# LaTeX must be installed and the Julia package
+# [TikzPictures.jl](https://github.com/sisl/TikzPictures.jl) must be imported
+# before Catlab is loaded.
 
 import TikzPictures
-using Catlab.Graphics
+using Catlab.WiringDiagrams, Catlab.Graphics
 
 # ## Examples
 
@@ -15,71 +16,63 @@ using Catlab.Graphics
 
 using Catlab.Doctrines
 
-A, B = Ob(FreeSymmetricMonoidalCategory, :A, :B)
-f = Hom(:f, A, B)
-g = Hom(:g, B, A)
-h = Hom(:h, otimes(A,B), otimes(A,B));
+A, B, C, D = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C, :D)
+f, g = Hom(:f, A, B), Hom(:g, B, A);
+
+# To start, here are a few very simple examples.
+
+to_tikz(f)
 #-
-to_tikz(f; arrowtip="Stealth", labels=true)
+to_tikz(f⋅g)
 #-
-to_tikz(compose(f,g); arrowtip="Stealth", labels=true)
+to_tikz(f⊗g)
+
+# Here is a more complex example, involving generators with compound domains and
+# codomains.
+
+h, k = Hom(:h, C, D),  Hom(:k, D, C)
+m, n = Hom(:m, B⊗A, A⊗B), Hom(:n, D⊗C, C⊗D)
+q = Hom(:l, A⊗B⊗C⊗D, D⊗C⊗B⊗A)
+
+to_tikz((f⊗g⊗h⊗k)⋅(m⊗n)⋅q⋅(n⊗m)⋅(h⊗k⊗f⊗g))
+
+# Identities and braidings appear as wires.
+
+to_tikz(id(A))
 #-
-comp1 = compose(otimes(g,f), h, otimes(f,g))
+to_tikz(braid(A,B))
 #-
-to_tikz(comp1)
-#-
-comp2 = compose(otimes(id(A),f), h, otimes(id(A),g))
-#-
-to_tikz(comp2)
-#-
-to_tikz(Hom(:H, otimes(A,A), otimes(B,B,B)))
-#-
-twist = compose(braid(A,A), otimes(f,f), braid(B,B))
-#-
-to_tikz(twist)
+to_tikz(braid(A,B) ⋅ (g⊗f) ⋅ braid(A,B))
+
+# The isomorphism $A \otimes B \otimes C \to C \otimes B \otimes A$ induced by
+# the permutation $(3\ 2\ 1)$ is a composite of braidings and identities.
+
+to_tikz((braid(A,B) ⊗ id(C)) ⋅ (id(B) ⊗ braid(A,C) ⋅ (braid(B,C) ⊗ id(A))))
 
 # ### Biproduct category
 
 A, B = Ob(FreeBiproductCategory, :A, :B)
 f = Hom(:f, A, B)
-g = Hom(:g, B, A);
-#-
-split = compose(mcopy(A), otimes(f,f))
-#-
-to_tikz(split)
-#-
-combine = compose(split, mmerge(B))
-#-
-to_tikz(combine, labels=true)
-#-
-to_tikz(compose(create(A), f, g, delete(A)))
 
-# ### Compact closed category 
+to_tikz(mcopy(A))
+#-
+to_tikz(delete(A))
+#-
+to_tikz(mcopy(A)⋅(f⊗f)⋅mmerge(B))
 
-A, B = Ob(FreeCompactClosedCategory, :A, :B)
+# ### Compact closed category
+
+# The unit and co-unit of a compact closed category appear as caps and cups.
+
+A, B = Ob(FreeBicategoryRelations, :A, :B)
 f = Hom(:f, A, B)
-g = Hom(:g, B, A)
-h = Hom(:h, otimes(A,B), otimes(A,B));
+
+to_tikz(dunit(A))
 #-
-to_tikz(dcounit(A); arrowtip="Stealth", labels=true)
-#-
-to_tikz(dunit(A); arrowtip="Stealth", labels=true)
-#-
-transpose = compose(
-  otimes(dunit(A), id(dual(B))),
-  otimes(id(dual(A)), f, id(dual(B))),
-  otimes(id(dual(A)), dcounit(B)),
-)
-#-
-to_tikz(transpose)
-#-
-trace = compose(
-  f,
-  otimes(dunit(A), id(B)),
-  otimes(id(dual(A)), h),
-  otimes(braid(dual(A),A), id(B)),
-  otimes(dcounit(A), id(B)),
-  g
-)
-#-
-to_tikz(trace)
+to_tikz(dcounit(A))
+
+# In a self-dual compact closed category, such as a bicategory of relations,
+# every morphism $f: A \to B$ has a transpose $f^\dagger: B \to A$ given by
+# bending wires:
+
+to_tikz((dunit(A) ⊗ id(B)) ⋅ (id(A) ⊗ f ⊗ id(B)) ⋅ (id(A) ⊗ dcounit(B)))

--- a/docs/literate/programs/algebraic_nets.jl
+++ b/docs/literate/programs/algebraic_nets.jl
@@ -16,7 +16,7 @@ display(f_cos)
 #-
 f = compose(mcopy(R),otimes(f_sin,f_cos),mmerge(R))
 #-
-to_tikz(f; labels=true)
+to_tikz(f)
 #-
 compile_expr(f; args=[:x])
 #-

--- a/src/graphics/TikZ.jl
+++ b/src/graphics/TikZ.jl
@@ -70,8 +70,7 @@ end
   name::String
   props::Vector{Property}
   coord::Union{Coordinate,Nothing}
-  # Allow nested pictures even though TikZ does not "officially" support them.
-  content::Union{String,Picture}
+  content::String
   
   Node(name::String; props=Property[], coord=nothing, content="") =
     new(name, props, coord, content)
@@ -180,16 +179,7 @@ function pprint(io::IO, node::Node, n::Int)
     print(io, " at ")
     pprint(io, node.coord)
   end
-  if isa(node.content, Picture)
-    println(io, " {")
-    pprint(io, node.content, n+2)
-    println(io)
-    indent(io, n)
-    print(io, "}")
-  else
-    print(io, " {$(node.content)}")
-  end
-  print(io, ";")
+  print(io, " {$(node.content)};")
 end
 
 function pprint(io::IO, edge::Edge, n::Int)

--- a/src/graphics/TikZ.jl
+++ b/src/graphics/TikZ.jl
@@ -30,25 +30,25 @@ abstract type Statement <: Expression end
 abstract type GraphStatement <: Expression end
 
 @auto_hash_equals struct Coordinate <: Expression
-  x::AbstractString
-  y::AbstractString
+  x::String
+  y::String
   
-  Coordinate(x::AbstractString, y::AbstractString) = new(x, y)
+  Coordinate(x::String, y::String) = new(x, y)
   Coordinate(x::Number, y::Number) = new(string(x), string(y))
 end
 
 @auto_hash_equals struct Property <: Expression
-  key::AbstractString
-  value::Union{AbstractString,Nothing}
+  key::String
+  value::Union{String,Nothing}
   
-  Property(key::AbstractString, value=nothing) = new(key, value)
+  Property(key::String, value=nothing) = new(key, value)
 end
 
 @auto_hash_equals struct PathOperation <: Expression
-  op::AbstractString
+  op::String
   props::Vector{Property}
   
-  PathOperation(op::AbstractString; props=Property[]) = new(op, props)
+  PathOperation(op::String; props=Property[]) = new(op, props)
 end
 
 @auto_hash_equals struct Picture <: Expression
@@ -67,31 +67,31 @@ end
 
 @auto_hash_equals struct Node <: Statement
   # FIXME: Name is optional, according to TikZ manual.
-  name::AbstractString
+  name::String
   props::Vector{Property}
   coord::Union{Coordinate,Nothing}
   # Allow nested pictures even though TikZ does not "officially" support them.
-  content::Union{AbstractString,Picture}
+  content::Union{String,Picture}
   
-  Node(name::AbstractString; props=Property[], coord=nothing, content="") =
+  Node(name::String; props=Property[], coord=nothing, content="") =
     new(name, props, coord, content)
 end
 
 @auto_hash_equals struct EdgeNode <: Expression
   props::Vector{Property}
-  content::Union{AbstractString,Nothing}
+  content::Union{String,Nothing}
   
   EdgeNode(; props=Property[], content=nothing) = new(props, content)
 end
 
 @auto_hash_equals struct Edge <: Statement
-  src::AbstractString
-  tgt::AbstractString
+  src::String
+  tgt::String
   op::PathOperation
   props::Vector{Property}
   node::Union{EdgeNode,Nothing}
   
-  Edge(src::AbstractString, tgt::AbstractString;
+  Edge(src::String, tgt::String;
        op=PathOperation("to"), props=Property[], node=nothing) =
     new(src, tgt, op, props, node)
 end
@@ -113,20 +113,20 @@ end
 end
 
 @auto_hash_equals struct GraphNode <: GraphStatement
-  name::AbstractString
+  name::String
   props::Vector{Property}
-  content::Union{AbstractString,Nothing}
+  content::Union{String,Nothing}
   
-  GraphNode(name::AbstractString; props=Property[], content=nothing) =
+  GraphNode(name::String; props=Property[], content=nothing) =
     new(name, props, content)
 end
 
 @auto_hash_equals struct GraphEdge <: GraphStatement
-  src::AbstractString
-  tgt::AbstractString
+  src::String
+  tgt::String
   props::Vector{Property}
   
-  GraphEdge(src::AbstractString, tgt::AbstractString; props=Property[]) =
+  GraphEdge(src::String, tgt::String; props=Property[]) =
     new(src, tgt, props)
 end
 

--- a/src/graphics/TikZ.jl
+++ b/src/graphics/TikZ.jl
@@ -39,7 +39,7 @@ end
 
 @auto_hash_equals struct Property <: Expression
   key::String
-  value::Union{String,Nothing}
+  value::Union{String,Vector{Property},Nothing}
   
   Property(key::String, value=nothing) = new(key, value)
 end
@@ -141,8 +141,8 @@ end
 
 """ Pretty-print the TikZ expression.
 """
-pprint(expr::Expression) = pprint(stdout, expr)
-pprint(io::IO, expr::Expression) = pprint(io, expr, 0)
+pprint(expr::Expression; kw...) = pprint(stdout, expr; kw...)
+pprint(io::IO, expr::Expression; kw...) = pprint(io, expr, 0; kw...)
 
 function pprint(io::IO, pic::Picture, n::Int)
   indent(io, n)
@@ -283,18 +283,22 @@ function pprint(io::IO, prop::Property, n::Int)
   print(io, prop.key)
   if !isnothing(prop.value)
     print(io, "=")
-    print(io, prop.value)
+    if prop.value isa Vector{Property}
+      pprint(io, prop.value, nested=true)
+    else
+      print(io, prop.value)
+    end
   end
 end
 
-function pprint(io::IO, props::Vector{Property}, n::Int=0)
+function pprint(io::IO, props::Vector{Property}, n::Int=0; nested::Bool=false)
   if !isempty(props)
-    print(io, "[")
+    print(io, nested ? "{" : "[")
     for (i, prop) in enumerate(props)
       pprint(io, prop)
       if (i < length(props)) print(io, ",") end
     end
-    print(io, "]")
+    print(io, nested ? "}" : "]")
   end
 end
 

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -63,11 +63,13 @@ function layout_to_tikz(diagram::WiringDiagram, opts::TikZOptions)
   for wire in wires(diagram)
     src, src_angle = tikz_port(diagram, wire.source)
     tgt, tgt_angle = tikz_port(diagram, wire.target)
-    push!(stmts, TikZ.Edge(src, tgt, op=
+    push!(stmts, TikZ.Edge(
+      src,
       TikZ.PathOperation("to"; props=[
         TikZ.Property("out", string(src_angle)),
         TikZ.Property("in", string(tgt_angle)),
-      ])
+      ]),
+      tgt,
     ))
   end
   stmts

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -11,8 +11,8 @@ using StaticArrays: StaticVector, SVector
 using ...Syntax: GATExpr, show_latex
 using ...WiringDiagrams, ...WiringDiagrams.WiringDiagramSerialization
 using ..WiringDiagramLayouts
-using ..WiringDiagramLayouts: AbstractVector2D, Vector2D, BoxLayout, PortLayout,
-  BoxShape, RectangleShape, CircleShape, JunctionShape, NoShape
+using ..WiringDiagramLayouts: AbstractVector2D, Vector2D, BoxLayout, BoxShape,
+  RectangleShape, CircleShape, JunctionShape, NoShape, position, normal
 import ..TikZ
 
 # Data types
@@ -95,11 +95,10 @@ end
 """
 function tikz_port(diagram::WiringDiagram, port::Port)
   name = box_id(diagram, [port.box])
-  layout = port_value(diagram, port)::PortLayout
-  x, y = tikz_position(layout.position)
+  x, y = tikz_position(position(port_value(diagram, port)))
   location = "\$($name.center)+($(x)em,$(y)em)\$"
-  normal = rad2deg(angle(layout.normal))
-  (location, normal)
+  normal_angle = rad2deg(angle(normal(diagram, port)))
+  (location, normal_angle)
 end
 
 function tikz_label(x, opts::TikZOptions)

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -138,7 +138,7 @@ function tikz_size(size::AbstractVector2D)::Vector{TikZ.Property}
   end
 end
 
-angle(v::AbstractVector2D) = Base.angle(v[1] + v[2]*im)
+angle(v::AbstractVector2D) = Base.angle(v[1] - v[2]*im)
 
 # TikZ shapes and styles
 ########################
@@ -169,9 +169,11 @@ const tikz_styles = OrderedDict(
   "junction" => [
     TikZ.Property("circle"),
     TikZ.Property("draw"), TikZ.Property("fill"),
+    TikZ.Property("inner sep", "0"),
   ],
   "invisible" => [
     TikZ.Property("draw", "none"),
+    TikZ.Property("inner sep", "0"),
   ],
 )
 

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -1,541 +1,127 @@
 """ Draw wiring diagrams using TikZ.
 """
 module TikZWiringDiagrams
-export to_tikz
+export to_tikz, layout_to_tikz
 
-using ...Doctrines: ObExpr, HomExpr, dom, codom, head, args, compose, id
+using Compat
+using Parameters
+using StaticArrays: StaticVector, SVector
+
 using ...Syntax: GATExpr, show_latex
-using ...WiringDiagrams
+using ...WiringDiagrams, ...WiringDiagrams.WiringDiagramSerialization
+using ..WiringDiagramLayouts
+using ..WiringDiagramLayouts: AbstractVector2D, Vector2D, BoxLayout, BoxShape,
+  RectangleShape, CircleShape, JunctionShape, NoShape
 import ..TikZ
 
 # Data types
 ############
 
-""" A wire (edge) in a TikZ wiring diagram.
+""" Internal data type for configurable options of Compose.jl wiring diagrams.
 """
-struct Wire
-  label::String
-  reverse::Bool
-  Wire(label::String; reverse::Bool=false) = new(label, reverse)
-end
-
-""" A bundle of wires in a TikZ wiring diagram.
-
-A graphical representation of an object.
-"""
-const Wires = Vector{Wire}
-
-""" A port on a box in a TikZ wiring diagram.
-"""
-struct Port
-  wire::Wire
-  anchor::String
-  angle::Int
-  show_label::Bool
-  Port(wire::Wire, anchor::String; angle::Int=0, show_label::Bool=true) =
-    new(wire, anchor, angle, show_label)
-end
-
-""" A box in a TikZ wiring diagram.
-
-A `Box` is a graphical representation of a morphism, and need not be rendered
-as a geometric box (rectangle).
-"""
-struct Box
-  node::TikZ.Node
-  inputs::Vector{Port}
-  outputs::Vector{Port}
+@with_kw_noshow struct TikZOptions
+  math_mode::Bool = true
 end
 
 # Wiring diagrams
 #################
 
-""" Draw a wiring diagram in TikZ for the given morphism expression.
-
-The diagram is constructed recursively, mirroring the structure of the formula.
-This is achieved by nesting TikZ pictures in TikZ nodes recursively--a feature
-not officially supported by TikZ but that is nonetheless in widespread use.
-
-Warning: Since our implementation uses the `remember picture` option, LaTeX must
-be run at least *twice* to fully render the picture. See (TikZ Manual,
-Sec 17.13).
+""" Draw a wiring diagram in TikZ.
 """
-function to_tikz(f::HomExpr;
-    font_size::Number=12, line_width::String="0.4pt", math_mode::Bool=true,
-    arrowtip::String="", labels::Bool=false,
-    box_size::Number=2, box_style::Dict=Dict(),
-    sequence_sep::Number=2, parallel_sep::Number=0.5)::TikZ.Picture
-  # Parse arguments.
-  # XXX: Storing the style parameters as a global variable is bad practice, but
-  # passing them around is really inconvenient. Is there a better approach?
-  global style = Dict(
-    :math_mode => math_mode, :arrowtip => !isempty(arrowtip), :labels => labels,
-    :box_size => box_size, :box_style => box_style,
-    :sequence_sep => sequence_sep, :parallel_sep => parallel_sep,
-  )
+function to_tikz(args...;
+    arrowtip::Union{String,Nothing}=nothing,
+    picture_props::Vector{TikZ.Property}=TikZ.Property[], kw...)
+  layout_kw = filter(p -> first(p) ∉ fieldnames(TikZOptions), kw)
+  diagram = layout_diagram(args...; layout_kw...)
   
-  # Draw input and output arrows by composing identities on either side of f. 
-  f_seq = collect(HomExpr, head(f) == :compose ? args(f) : [f])
-  if head(f) == :id
-    insert!(f_seq, 1, id(dom(f)))
+  tikz_kw = filter(p -> first(p) ∈ fieldnames(TikZOptions), kw)
+  stmts = layout_to_tikz(diagram; tikz_kw...)
+  props = copy(picture_props)
+  if !isnothing(arrowtip)
+    push!(props, TikZ.Property("decoration", 
+      "{markings, mark=at position 0.5 with {\\arrow{$arrowtip}}}"))
+  end
+  TikZ.Picture(stmts...; props=props)
+end
+
+""" Draw a wiring diagram in TikZ using the given layout.
+"""
+function layout_to_tikz(diagram::WiringDiagram; kw...)::Vector{<:TikZ.Statement}
+  layout_to_tikz(diagram, TikZOptions(; kw...))
+end
+
+function layout_to_tikz(diagram::WiringDiagram, opts::TikZOptions)
+  name(v::Int) = box_id(diagram, [v])
+  stmts = TikZ.Statement[
+    tikz_node(diagram, opts, name=name(input_id(diagram)), style="outer box");
+    [ tikz_node(box(diagram, v), opts, name=name(v)) for v in box_ids(diagram) ]
+  ]
+  # TODO: Edges.
+  stmts
+end
+
+function tikz_node(box::AbstractBox, opts::TikZOptions; kw...)
+  tikz_node(box.value::BoxLayout, opts; kw...)
+end
+function tikz_node(layout::BoxLayout, opts::TikZOptions;
+    name::Union{String,Nothing}=nothing, style::Union{String,Nothing}=nothing)
+  if isnothing(style)
+    style = tikz_shapes[layout.shape]
+  end
+  content = layout.shape in tikz_content_shapes ?
+    tikz_label(layout.value, opts) : ""
+  TikZ.Node(name,
+    props=[TikZ.Property(style); tikz_size(layout.size)],
+    coord=tikz_coordinate(layout.position),
+    content=content)
+end
+
+const tikz_shapes = Dict(
+  RectangleShape => "box",
+  CircleShape => "circular box",
+  JunctionShape => "junction",
+  NoShape => "invisible",
+)
+const tikz_content_shapes = Set([
+  RectangleShape,
+  CircleShape,
+])
+
+# TikZ helpers
+##############
+
+function tikz_label(x, opts::TikZOptions)
+  text = sprint(show, x)
+  opts.math_mode ? string("\$", text, "\$") : text
+end
+function tikz_label(expr::GATExpr, opts::TikZOptions)
+  if opts.math_mode
+    string("\$", sprint(show_latex, expr), "\$")
   else
-    if head(dom(f)) != :munit
-      insert!(f_seq, 1, id(dom(f)))
-    end
-    if head(codom(f)) != :munit
-      push!(f_seq, id(codom(f)))
-    end
+    sprint(show, expr)
   end
-  
-  # Create node for extended morphism.
-  box_tikz = length(f_seq) == 1 ? box("n", first(f_seq)) : sequence("n", f_seq)
-  
-  # Create picture with this single node.
-  props = [
-    TikZ.Property("remember picture"),
-    TikZ.Property("font", 
-                  "{\\fontsize{$font_size}{$(round(1.2*font_size;digits=2))}}"),
-    TikZ.Property("container/.style", "{inner sep=0}"),
-    TikZ.Property("every path/.style", "{solid, line width=$line_width}"),
-  ]
-  if !isempty(arrowtip)
-    decoration = "{markings, mark=at position 0.5 with {\\arrow{$arrowtip}}}"
-    push!(props, TikZ.Property("decoration", decoration))
+end
+tikz_label(::Nothing, opts::TikZOptions) = ""
+
+function tikz_position(position::AbstractVector2D)::AbstractVector2D
+  # TikZ's default coordinate system has the positive y-axis going upwards.
+  x, y = position
+  SVector(x, -y)
+end
+function tikz_coordinate(position::AbstractVector2D)::TikZ.Coordinate
+  TikZ.Coordinate(tikz_position(position)...)
+end
+
+function tikz_size(size::AbstractVector2D)::Vector{TikZ.Property}
+  width, height = size
+  if width == 0 && height == 0
+    TikZ.Property[]
+  elseif width == height
+    [ TikZ.Property("minimum size", "$(width)em") ]
+  else
+    [ TikZ.Property("minimum width", "$(width)em"), 
+      TikZ.Property("minimum height", "$(height)em") ]
   end
-  if math_mode
-    append!(props, [ TikZ.Property("execute at begin node", "\$"),
-                     TikZ.Property("execute at end node", "\$") ])
-  end
-  TikZ.Picture(box_tikz.node; props=props)
-end
-
-""" Create wires for an object expression.
-"""
-function wires(A::ObExpr)::Wires
-  error("TikZ wires not implement for $(typeof(A))")
-end
-
-""" Create box for a morphism expression.
-"""
-function box(name::String, f::HomExpr)::Box
-  error("TikZ box not implement for $(typeof(f))")
-end
-
-# Elements of wiring diagrams
-#############################
-
-""" A rectangle, the default style for generators.
-"""
-function rect(name::String, content::String, dom::Wires, codom::Wires;
-              padding::String="0.333em", rounded::Bool=true)::Box
-  dom_ports = box_ports(dom, name, dir="west", angle=180)
-  codom_ports = box_ports(codom, name, dir="east", angle=0)
-  size = box_size(max(length(dom_ports), length(codom_ports)))
-  
-  box_style = style[:box_style]
-  props = [
-    TikZ.Property("draw"),
-    TikZ.Property("solid"),
-    TikZ.Property("inner sep", get(box_style, :padding, padding)),
-    TikZ.Property("rectangle"),
-    TikZ.Property(get(box_style, :rounded, rounded) ?
-                  "rounded corners" : "sharp corners"),
-    TikZ.Property("minimum height", "$(size)em"),
-  ]
-  node = TikZ.Node(name; content=content, props=props)
-  Box(node, dom_ports, codom_ports)
-end
-function rect(name::String, f::HomExpr{:generator}; kw...)::Box
-  rect(name, label(f), wires(dom(f)), wires(codom(f)); kw...)
-end
-
-""" A trapezium node, the default style for generators in dagger categories.
-
-The node content is a nested TikZ picture that contains a single visible node.
-Nesting pictures even at this level may seem crazy, but it's the only way I know
-to get a bounding box on the inner node, regardless of its shape, *before* it's
-rendered.
-"""
-function trapezium(name::String, content::String, dom::Wires, codom::Wires;
-                   padding::String="0.333em", rounded::Bool=true,
-                   angle::Int=80, reverse::Bool=false)::Box
-  dom_ports = box_ports(dom, name, dir="west", angle=180)
-  codom_ports = box_ports(codom, name, dir="east", angle=0)
-  size = box_size(max(length(dom_ports), length(codom_ports)))
-  
-  box_style = style[:box_style]
-  props = [
-    TikZ.Property("draw"),
-    TikZ.Property("solid"),
-    TikZ.Property("inner sep", get(box_style, :padding, padding)),
-    TikZ.Property("trapezium"),
-    TikZ.Property("trapezium angle", string(get(box_style, :angle, angle))),
-    TikZ.Property("trapezium stretches body"),
-    TikZ.Property("shape border rotate", reverse ? "90" : "270"),
-    TikZ.Property(get(box_style, :rounded, rounded) ?
-                  "rounded corners" : "sharp corners"),
-    # Actually the height because of rotation.
-    TikZ.Property("minimum width", "$(size)em"),
-  ]
-  node = TikZ.Node("$name box"; content=content, props=props)
-  picture = TikZ.Picture(node)
-  
-  props = [ TikZ.Property("container") ]
-  node = TikZ.Node(name; content=picture, props=props)
-  Box(node, dom_ports, codom_ports)
-end
-function trapezium(name::String, f::HomExpr{:generator}; kw...)::Box
-  trapezium(name, label(f), wires(dom(f)), wires(codom(f)); kw...)
-end
-
-""" A triangle node.
-
-Supports any number of inputs and outputs, but looks best with at most one
-input and at most one output.
-"""
-function triangle(name::String, content::String, dom::Wires, codom::Wires;
-                  padding::String="0.333em", rounded::Bool=false,
-                  reverse::Bool=false)::Box
-  dom_ports = [ Port(w, "$name.west", angle=180) for w in dom ]
-  codom_ports = [ Port(w, "$name.east", angle=0) for w in codom ]
-  box_style = style[:box_style]
-  props = [
-    TikZ.Property("draw"),
-    TikZ.Property("solid"),
-    TikZ.Property("inner sep", get(box_style, :padding, padding)),
-    TikZ.Property("isosceles triangle"),
-    TikZ.Property("isosceles triangle stretches"),
-    TikZ.Property("shape border rotate", reverse ? "180" : "0"),
-    TikZ.Property(get(box_style, :rounded, rounded) ?
-                  "rounded corners" : "sharp corners"),
-    TikZ.Property("minimum height", "$(box_size(1))em"),
-  ]
-  node = TikZ.Node(name; content=content, props=props)
-  Box(node, dom_ports, codom_ports)
-end
-function triangle(name::String, f::HomExpr{:generator}; kw...)::Box
-  triangle(name, label(f), wires(dom(f)), wires(codom(f)); kw...)
-end
-
-""" Straight lines, used to draw identity morphisms.
-"""
-function lines(name::String, wires::Wires)::Box
-  dom_ports = box_ports(wires, name, dir="center", angle=180)
-  codom_ports = box_ports(wires, name, dir="center", angle=0)
-  height = box_size(length(wires))
-  props = [ TikZ.Property("minimum height", "$(height)em") ]
-  node = TikZ.Node(name; props=props)
-  Box(node, dom_ports, codom_ports)
-end
-lines(name::String, A::ObExpr) = lines(name, wires(A))
-
-""" Boxes in sequence, used to draw compositions.
-"""
-function sequence(name::String, homs::Vector)::Box
-  sequence_sep = style[:sequence_sep]
-  edge_props = style[:arrowtip] ?
-    [ TikZ.Property("postaction", "{decorate}") ] : []
-  edge_node_props = [
-    TikZ.Property("above", "0.25em"),
-    TikZ.Property("midway")
-  ]
-  
-  mors = [ box("$name$i", g) for (i,g) in enumerate(homs) ]
-  stmts = TikZ.Statement[ mors[1].node ]
-  for i = 2:length(mors)
-    push!(mors[i].node.props,
-          TikZ.Property("right=$(sequence_sep)em of $name$(i-1))"))
-    push!(stmts, mors[i].node)
-    for j = 1:length(mors[i].inputs)
-      src_port = mors[i-1].outputs[j]
-      tgt_port = mors[i].inputs[j]
-      
-      # Create edge node for label. We use the source port, not the target port
-      # (see also `GraphvizWiring`).
-      wire = src_port.wire
-      node = if (style[:labels] && src_port.show_label && tgt_port.show_label)
-        TikZ.EdgeNode(content=wire.label, props=edge_node_props)
-      else
-        nothing
-      end
-      
-      # Create path operation and draw edge.
-      if wire.reverse
-        src_port, tgt_port = tgt_port, src_port
-      end
-      op = TikZ.PathOperation("to"; props=[
-        TikZ.Property("out", string(src_port.angle)),
-        TikZ.Property("in", string(tgt_port.angle)),
-      ])
-      edge = TikZ.Edge(src_port.anchor, tgt_port.anchor;
-                       op=op, props=edge_props, node=node)
-      push!(stmts, edge)
-    end
-  end
-
-  props = [ TikZ.Property("container") ]
-  node = TikZ.Node(name; content=TikZ.Picture(stmts...), props=props)
-  Box(node, first(mors).inputs, last(mors).outputs)
-end
-
-""" Boxes in parallel, used to draw monoidal products.
-"""
-function parallel(name::String, homs::Vector)::Box
-  parallel_sep = style[:parallel_sep]
-  
-  mors = []
-  for (i,g) in enumerate(homs)
-    mor = box("$name$i", g)
-    if i > 1
-      push!(mor.node.props,
-            TikZ.Property("below=$(parallel_sep)em of $name$(i-1)"))
-    end
-    push!(mors, mor)
-  end
-  stmts = TikZ.Statement[ mor.node for mor in mors ]
-
-  props = [ TikZ.Property("container") ]
-  node = TikZ.Node(name; content=TikZ.Picture(stmts...), props=props)
-  inputs = vcat([ mor.inputs for mor in mors]...)
-  outputs = vcat([ mor.outputs for mor in mors]...)
-  Box(node, inputs, outputs)
-end
-
-""" Cross two wires.
-
-Used to draw braid morphisms in symmatric monoidal categories.
-""" 
-function crossing(name::String, wire1::Wire, wire2::Wire)
-  dom = [ Port(wire1, "$name.center", angle=135),
-          Port(wire2, "$name.center", angle=225) ]
-  codom = [ Port(wire2, "$name.center", angle=45),
-            Port(wire1, "$name.center", angle=315) ]
-  props = [
-    TikZ.Property("minimum height", "$(box_size(2))em")
-  ]
-  node = TikZ.Node(name; props=props)
-  Box(node, dom, codom)
-end
-crossing(name::String, A::ObExpr) = crossing(name, wires(A)...)
-
-""" A junction of wires drawn as a circle.
-
-Used to morphisms in internal monoids and comonoids.
-
-Implemented using a small, visible node for the point and a big, invisible node
-as a spacer. FIXME: Is there a more elegant way to achieve the desired margin?
-"""
-function junction_circle(name::String, wires_in::Wires, wires_out::Wires;
-                         fill::Bool=true)
-  dom = circle_ports(wires_in, "$name point", "west";
-                     show_label = length(wires_in) <= 1)
-  codom = circle_ports(wires_out, "$name point", "east";
-                       show_label = length(wires_out) <= 1)
-  size = box_size(max(length(dom), length(codom)))
-  pic = TikZ.Picture(
-    TikZ.Node("$name box"; props=[
-      TikZ.Property("minimum height", "$(size)em"),
-    ]),
-    TikZ.Node("$name point"; props=[
-      TikZ.Property("draw"),
-      TikZ.Property(fill ? "fill" : "solid"),
-      TikZ.Property("circle"),
-      TikZ.Property("minimum size", "0.333em"),
-      TikZ.Property("above", "0 of $name box.center"),
-      TikZ.Property("anchor", "center"),
-    ]),
-  )
-  node = TikZ.Node(name; content=pic, props=[TikZ.Property("container")])
-  Box(node, dom, codom)
-end
-function junction_circle(name::String, dom::ObExpr, codom::ObExpr; kw...)
-  junction_circle(name, wires(dom), wires(codom); kw...)
-end
-function junction_circle(name::String, f::HomExpr; kw...)
-  junction_circle(name, dom(f), codom(f); kw...)
-end
-
-""" A cup.
-
-Used to draw counit morphisms in compact closed categories.
-"""
-function cup(name::String, wire1::Wire, wire2::Wire)
-  ports = [ Port(wire1, "$name.center", angle=90, show_label=false),
-            Port(wire2, "$name.center", angle=270, show_label=false) ]
-  props = [
-    TikZ.Property("minimum height", "$(box_size(2))em")
-  ]
-  node = TikZ.Node(name; props=props)
-  Box(node, ports, [])
-end
-cup(name::String, A::ObExpr) = cup(name, wires(A)...)
-
-""" A cap.
-
-Used to draw unit morphisms in compact closed categories.
-"""
-function cap(name::String, wire1::Wire, wire2::Wire)
-  ports = [ Port(wire1, "$name.center", angle=90, show_label=false),
-            Port(wire2, "$name.center", angle=270, show_label=false) ]
-  props = [
-    TikZ.Property("minimum height", "$(box_size(2))em")
-  ]
-  node = TikZ.Node(name; props=props)
-  Box(node, [], ports)
-end
-cap(name::String, A::ObExpr) = cap(name, wires(A)...)
-
-# Helper functions
-##################
-
-""" Compute the size of a box from the number of its ports.
-
-We use the unique formula consistent with the monoidal product, meaning that
-the size of a product of generator boxes depends only on the total number of
-ports, not the number of generators.
-"""
-function box_size(ports::Int)::Number
-  m = max(1, ports)
-  m * style[:box_size] + (m-1) * style[:parallel_sep]
-end
-
-""" Create ports for a rectangular box.
-
-This mainly involves computing the locations of anchors. The anchors are
-consistent with the monoidal product (see `box_size`).
-"""
-function box_ports(wires::Wires, name::String;
-                   dir::String="center", kw...)::Vector{Port}
-  box_size, parallel_sep = style[:box_size], style[:parallel_sep]
-  m = length(wires)
-  if m == 0
-    return []
-  elseif m == 1
-    return [ Port(wires[1], "$name.$dir"; kw...) ]
-  end
-  
-  result = []
-  start = (m*box_size + (m-1)*parallel_sep) / 2
-  for (i,wire) in enumerate(wires)
-    offset = box_size/2 + (i-1)*(box_size+parallel_sep)
-    anchor = "\$($name.$dir)+(0,$(start-offset)em)\$"
-    push!(result, Port(wire, anchor; kw...))
-  end
-  return result
-end
-
-""" Create ports for a circular node.
-"""
-function circle_ports(wires::Wires, name::String, dir::String;
-                      kw...)::Vector{Port}
-  @assert dir in ("west", "east")
-  m = length(wires)
-  angles = round.(Int, range(0,stop=180,length=m+2)[2:end-1])
-  if dir == "west"
-    angles = mod.(angles .+ 90, 360)
-  elseif dir == "east"
-    angles = reverse(mod.(angles .- 90, 360))
-  end
-  Port[ Port(wire, "$name.$angle"; angle=angle, kw...)
-            for (wire, angle) in zip(wires, angles) ]
-end
-
-# Defaults
-##########
-
-# These methods are reasonable to define for the base expression types since
-# they will rarely be changed.
-
-wires(A::ObExpr{:generator}) = [ Wire(label(A)) ]
-wires(A::ObExpr{:munit}) = Wire[]
-wires(A::ObExpr{:otimes}) = vcat(map(wires, args(A))...)
-
-box(name::String, f::HomExpr{:id}) = lines(name, dom(f))
-box(name::String, f::HomExpr{:compose}) = sequence(name, args(f))
-box(name::String, f::HomExpr{:otimes}) = parallel(name, args(f))
-box(name::String, f::HomExpr{:braid}) = crossing(name, dom(f))
-
-function label(expr::GATExpr{:generator})::String
-  sprint(style[:math_mode] ? show_latex : show, expr)
-end
-
-""" Default renderers for specific syntax systems.
-"""
-module Defaults
-  import ..TikZWiringDiagrams: Wire, box, wires, label, rect, trapezium,
-    junction_circle, cup, cap
-  using Catlab.Doctrines
-  using Catlab.Syntax
-  
-  generator(expr::GATExpr)::GATExpr{:generator} = first(expr)
-  
-  # Category
-  box(name::String, f::FreeCategory.Hom{:generator}) = rect(name, f)
-  
-  # Dagger category
-  # Assumes that daggers are fully distributed (as in this syntax system).
-  Syntax = FreeDaggerCategory
-  box(name::String, f::Syntax.Hom{:generator}) = trapezium(name, f)
-  box(name::String, f::Syntax.Hom{:dagger}) = trapezium(name,
-    label(generator(f)), wires(dom(f)), wires(codom(f)); reverse=true)
-
-  # Symmetric monoidal category
-  Syntax = FreeSymmetricMonoidalCategory
-  box(name::String, f::Syntax.Hom{:generator}) = rect(name, f)
-
-  # (Co)cartesian category
-  Syntax = FreeCartesianCategory
-  box(name::String, f::Syntax.Hom{:generator}) = rect(name, f)
-  box(name::String, f::Syntax.Hom{:mcopy}) = junction_circle(name, f)
-  box(name::String, f::Syntax.Hom{:delete}) = junction_circle(name, f)
-  
-  Syntax = FreeCocartesianCategory
-  box(name::String, f::Syntax.Hom{:generator}) = rect(name, f)
-  box(name::String, f::Syntax.Hom{:mmerge}) = junction_circle(name, f)
-  box(name::String, f::Syntax.Hom{:create}) = junction_circle(name, f)
-  
-  # Biproduct category
-  Syntax = FreeBiproductCategory
-  box(name::String, f::Syntax.Hom{:generator}) = rect(name, f)
-  box(name::String, f::Syntax.Hom{:mcopy}) = junction_circle(name, f)
-  box(name::String, f::Syntax.Hom{:delete}) = junction_circle(name, f)
-  box(name::String, f::Syntax.Hom{:mmerge}) = junction_circle(name, f)
-  box(name::String, f::Syntax.Hom{:create}) = junction_circle(name, f)
-  
-  # Compact closed category
-  # Assumes that duals are fully distributed (as in this syntax system).
-  Syntax = FreeCompactClosedCategory
-  wires(A::Syntax.Ob{:dual}) = [ Wire(label(generator(A)); reverse=true) ]
-  box(name::String, f::Syntax.Hom{:generator}) = rect(name, f)
-  box(name::String, f::Syntax.Hom{:dunit}) = cap(name, codom(f))
-  box(name::String, f::Syntax.Hom{:dcounit}) = cup(name, dom(f))
-  
-  # Bicategory of relations
-  Syntax = FreeBicategoryRelations
-  box(name::String, f::Syntax.Hom{:generator}) = trapezium(name, f)
-  box(name::String, f::Syntax.Hom{:dagger}) = trapezium(name,
-    label(generator(f)), wires(dom(f)), wires(codom(f)); reverse=true)
-  box(name::String, f::Syntax.Hom{:dunit}) = cap(name, codom(f))
-  box(name::String, f::Syntax.Hom{:dcounit}) = cup(name, dom(f))
-  box(name::String, f::Syntax.Hom{:mcopy}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:delete}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:mmerge}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:create}) = junction_circle(name, f; fill=false)
-  
-  Syntax = FreeAbelianBicategoryRelations
-  box(name::String, f::Syntax.Hom{:generator}) = trapezium(name, f)
-  box(name::String, f::Syntax.Hom{:dagger}) = trapezium(name,
-    label(generator(f)), wires(dom(f)), wires(codom(f)); reverse=true)
-  box(name::String, f::Syntax.Hom{:dunit}) = cap(name, codom(f))
-  box(name::String, f::Syntax.Hom{:dcounit}) = cup(name, dom(f))
-  box(name::String, f::Syntax.Hom{:mcopy}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:delete}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:mmerge}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:create}) = junction_circle(name, f; fill=false)
-  box(name::String, f::Syntax.Hom{:plus}) = junction_circle(name, f; fill=true)
-  box(name::String, f::Syntax.Hom{:zero}) = junction_circle(name, f; fill=true)
-  box(name::String, f::Syntax.Hom{:coplus}) = junction_circle(name, f; fill=true)
-  box(name::String, f::Syntax.Hom{:cozero}) = junction_circle(name, f; fill=true)
 end
 
 end

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -324,9 +324,12 @@ end
 function layout_circular_ports(port_kind::PortKind, port_values::Vector,
                                radius::Real, opts::LayoutOptions; pad::Bool=true)
   n = length(port_values)
-  θ1, θ2 = is_horizontal(opts.orientation) ? (π/2, -π/2) : (-π, 0)
+  port_dir = svector(opts, port_sign(port_kind, opts.orientation), 0)
+  θ1, θ2 = if port_dir == SVector(1,0); (π/2, -π/2)
+    elseif port_dir == SVector(0,1); (-π, 0)
+    elseif port_dir == SVector(-1,0); (π/2, 3π/2)
+    elseif port_dir == SVector(0,-1); (0, π) end
   θs = collect(pad ? range(θ1,θ2,length=n+2)[2:n+1] : range(θ1,θ2,length=n))
-  θs = port_sign(port_kind, opts.orientation) == -1 ? reverse(θs) : θs
   dirs = [ SVector(cos(θ),-sin(θ)) for θ in θs ] # positive y-axis downwards
   PortLayout[ PortLayout(value, radius * dir, dir)
               for (value, dir) in zip(port_values, dirs) ]

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -340,6 +340,19 @@ function layout_ports!(diagram::WiringDiagram, opts::LayoutOptions)
   diagram
 end
 
+function position(diagram::WiringDiagram, port::Port)
+  pos = position(port_value(diagram, port))
+  if !(port.box in (input_id(diagram), output_id(diagram)))
+    pos += position(box(diagram, port.box))
+  end
+  pos
+end
+
+function normal(diagram::WiringDiagram, port::Port)
+  sgn = port.box in (input_id(diagram), output_id(diagram)) ? -1 : +1
+  sgn * normal(port_value(diagram, port))
+end
+
 # Wire layout
 #############
 

--- a/src/programs/AlgebraicNets.jl
+++ b/src/programs/AlgebraicNets.jl
@@ -19,7 +19,6 @@ import ...Doctrines: MonoidalCategoryWithBidiagonals, ObExpr, HomExpr, Ob, Hom,
 import ...Meta: concat_expr
 import ...Syntax: show_latex, show_unicode
 using ...WiringDiagrams: WiringLayer
-import ...Graphics.TikZWiringDiagrams: box, wires, rect, junction_circle
 using ..JuliaPrograms
 import ..JuliaPrograms: compile, compile_expr, compile_block, genvar, genvars,
   to_function_expr, generator_expr, input_exprs
@@ -323,13 +322,5 @@ function show_unicode(io::IO, expr::AlgebraicNet.Hom{:linear}; kw...)
   value = first(expr)
   print(io, "linear{$value}")
 end
-
-box(name::String, f::AlgebraicNet.Hom{:generator}) = rect(name, f; rounded=false)
-box(name::String, f::AlgebraicNet.Hom{:linear}) =
-  rect(name, string(first(f)), wires(dom(f)), wires(codom(f)); rounded=true)
-box(name::String, f::AlgebraicNet.Hom{:mcopy}) = junction_circle(name, f; fill=false)
-box(name::String, f::AlgebraicNet.Hom{:delete}) = junction_circle(name, f; fill=false)
-box(name::String, f::AlgebraicNet.Hom{:mmerge}) = junction_circle(name, f; fill=true)
-box(name::String, f::AlgebraicNet.Hom{:create}) = junction_circle(name, f; fill=true)
 
 end

--- a/test/graphics/GraphvizWiringDiagrams.jl
+++ b/test/graphics/GraphvizWiringDiagrams.jl
@@ -6,12 +6,12 @@ using Catlab.Doctrines, Catlab.WiringDiagrams
 using Catlab.Graphics
 import Catlab.Graphics: Graphviz
 
-function stmts(graph::Graphviz.Graph, stmt_type::Type)
-  [ stmt for stmt in graph.stmts if stmt isa stmt_type ]
+function stmts(graph::Graphviz.Graph, type::Type)
+  [ stmt for stmt in graph.stmts if stmt isa type ]
 end
-function stmts(graph::Graphviz.Graph, stmt_type::Type, attr::Symbol)
+function stmts(graph::Graphviz.Graph, type::Type, attr::Symbol)
   [ stmt.attrs[attr] for stmt in graph.stmts
-    if stmt isa stmt_type && haskey(stmt.attrs, attr) ]
+    if stmt isa type && haskey(stmt.attrs, attr) ]
 end
 
 A, B = Ob(FreeBiproductCategory, :A, :B)

--- a/test/graphics/TikZ.jl
+++ b/test/graphics/TikZ.jl
@@ -26,20 +26,26 @@ spprint(expr::Expression) = sprint(pprint, expr)
   "\\node (f) at (1,0) {fun};"
 
 # Edge statement
-@test spprint(Edge("f","g")) == "\\draw (f) to (g);"
-@test spprint(Edge("f","g"; props=[Property("red")])) == "\\draw[red] (f) to (g);"
-@test spprint(Edge("f","g"; node=EdgeNode())) == "\\draw (f) to node (g);"
-@test spprint(Edge("f","g"; node=EdgeNode(;props=[Property("circle")],content="e"))) ==
+const PathOp = PathOperation
+@test spprint(Edge("f", PathOp("to"), "g")) == "\\draw (f) to (g);"
+@test spprint(Edge("f", PathOp("to"), "g"; props=[Property("red")])) ==
+  "\\draw[red] (f) to (g);"
+@test spprint(Edge("f", PathOp("to"), EdgeNode(), "g")) ==
+  "\\draw (f) to node (g);"
+@test spprint(Edge("f", PathOp("to"),
+              EdgeNode(; props=[Property("circle")], content="e"), "g")) ==
   "\\draw (f) to node[circle] {e} (g);"
-@test spprint(Edge("f","g"; op=PathOperation("to"; props=[Property("out","0")]))) ==
+@test spprint(Edge("f", PathOp("to"; props=[Property("out","0")]), "g")) ==
   "\\draw (f) to[out=0] (g);"
+@test spprint(Edge("f", PathOp("--"), "g", PathOp("--"), "h")) ==
+  "\\draw (f) -- (g) -- (h);"
 
 # Picture statement
 @test spprint(
 Picture(
   Node("f"),
   Node("g"),
-  Edge("f","g")
+  Edge("f",PathOp("to"),"g")
 )) == """
 \\begin{tikzpicture}
   \\node (f) {};
@@ -57,7 +63,7 @@ Picture(
 Picture(
   Scope(Node("f"); props=[Property("red")]),
   Scope(Node("g"); props=[Property("blue")]),
-  Edge("f","g")
+  Edge("f",PathOp("to"),"g")
 )) == """
 \\begin{tikzpicture}
   \\begin{scope}[red]
@@ -111,7 +117,7 @@ Graph(
 # Matrix statement
 @test spprint(
 MatrixNode(
-  [ [[Node("f")]]              [[Edge("g1","g2")]]; 
+  [ [[Node("f")]]              [[Edge("g1",PathOp("to"),"g2")]];
     [[Node("h1"),Node("h2")]]  [[Node("i1"),Node("i2")]] ];
   props=[Property("draw","red")]
 )) == """

--- a/test/graphics/TikZ.jl
+++ b/test/graphics/TikZ.jl
@@ -8,6 +8,12 @@ using Catlab.Graphics.TikZ
 
 spprint(expr::Expression) = sprint(pprint, expr)
 
+# Properties
+@test spprint(Property("circle")) == "circle"
+@test spprint(Property("fill","red")) == "fill=red"
+@test spprint(Property("style",[Property("circle"),Property("fill","red")])) ==
+  "style={circle,fill=red}"
+
 # Node statement
 @test spprint(Node("f")) == "\\node (f) {};"
 @test spprint(Node("f"; props=[Property("circle")])) == 
@@ -63,7 +69,7 @@ Picture(
   \\draw (f) to (g);
 \\end{tikzpicture}"""
 
-# Graph, GraphScope, GraphNode, GraphEdge statements
+# Graph statements
 @test spprint(
 Graph(
   GraphNode("f";content="fun"),

--- a/test/graphics/TikZ.jl
+++ b/test/graphics/TikZ.jl
@@ -46,35 +46,6 @@ Picture(
   \\node (f) {};
 \\end{tikzpicture}"""
 
-@test spprint( # Nested pictures
-Picture(
-  Node("outer1"; content=
-    Picture(
-      Node("inner1"),
-      Node("inner2")
-    )),
-  Node("outer2"; content=
-    Picture(
-      Node("inner3"),
-      Node("inner4")
-    ));
-  props=[Property("remember picture")]
-)) == """
-\\begin{tikzpicture}[remember picture]
-  \\node (outer1) {
-    \\begin{tikzpicture}
-      \\node (inner1) {};
-      \\node (inner2) {};
-    \\end{tikzpicture}
-  };
-  \\node (outer2) {
-    \\begin{tikzpicture}
-      \\node (inner3) {};
-      \\node (inner4) {};
-    \\end{tikzpicture}
-  };
-\\end{tikzpicture}"""
-
 # Scope statement
 @test spprint(
 Picture(


### PR DESCRIPTION
Part 2 of #46 and follow-up to #66. A few features are missing and will be documented in the issues.