### PR TITLE
Type-parametrized wiring diagrams

### DIFF
--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -337,12 +337,12 @@ end
 """
 function generator_like(expr::GATExpr, value)::GATExpr
   invoke_term(
-    parentmodule(typeof(expr)),
-    nameof(typeof(expr)),
-    value,
-    type_args(expr)...
-  )
+    syntax_module(expr), nameof(typeof(expr)), value, type_args(expr)...)
 end
+
+""" Get syntax module of given expression.
+"""
+syntax_module(expr::GATExpr) = parentmodule(typeof(expr))
 
 # Functors
 ##########
@@ -395,8 +395,7 @@ function functor(types::Tuple, expr::GATExpr;
   end
   
   # Invoke the constructor in the codomain category!
-  syntax_module = parentmodule(typeof(expr))
-  signature_module = syntax_module.signature()
+  signature_module = syntax_module(expr).signature()
   invoke_term(signature_module, types, name, term_args...)
 end
 

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -180,7 +180,7 @@ function compose_with_layout!(d1::WiringDiagram, d2::WiringDiagram, opts::Layout
   place_adjacent!(d1, d2; dir=dir, pad=-opts.sequence_pad)
   substitute_with_layout!(size_to_fit!(diagram, opts, pad=false))
 end
-function compose_with_layout!(diagrams::Vector{WiringDiagram}, opts::LayoutOptions)
+function compose_with_layout!(diagrams::Vector{<:WiringDiagram}, opts::LayoutOptions)
   foldl((d1,d2) -> compose_with_layout!(d1, d2, opts), diagrams)
 end
 
@@ -195,7 +195,7 @@ function otimes_with_layout!(d1::WiringDiagram, d2::WiringDiagram, opts::LayoutO
   place_adjacent!(d1, d2; dir=dir, pad=-opts.parallel_pad)
   substitute_with_layout!(size_to_fit!(diagram, opts, pad=false))
 end
-function otimes_with_layout!(diagrams::Vector{WiringDiagram}, opts::LayoutOptions)
+function otimes_with_layout!(diagrams::Vector{<:WiringDiagram}, opts::LayoutOptions)
   foldl((d1,d2) -> otimes_with_layout!(d1, d2, opts), diagrams)
 end
 

--- a/src/programs/JuliaPrograms.jl
+++ b/src/programs/JuliaPrograms.jl
@@ -287,7 +287,7 @@ end
 """
 function make_lookup_table(pres::Presentation, names)::Dict{Symbol,Any}
   # FIXME: Presentations should be uniquely associated with syntax systems.
-  syntax_module = parentmodule(typeof(first(pres.generators)))
+  syntax_module = Syntax.syntax_module(first(pres.generators))
   signature = syntax_module.signature().class().signature
   terms = Set([ term.name for term in signature.terms ])
   

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -30,16 +30,18 @@ The objects in categories of wiring diagrams.
 @auto_hash_equals struct Ports{Value}
   ports::Vector{Value}
 end
-Base.eachindex(A::Ports) = eachindex(A.ports)
+Base.iterate(A::Ports, args...) = iterate(A.ports, args...)
+Base.keys(A::Ports) = keys(A.ports)
 Base.length(A::Ports) = length(A.ports)
+Base.eltype(A::Ports{Value}) where Value = Value
 
 # Constructors.
 
 function WiringDiagram(value::Any, inputs::Ports, outputs::Ports)
-  WiringDiagram(value, inputs.ports, outputs.ports)
+  WiringDiagram(value, collect(ports), collect(outputs))
 end
 function WiringDiagram(inputs::Ports, outputs::Ports)
-  WiringDiagram(inputs.ports, outputs.ports)
+  WiringDiagram(collect(inputs), collect(outputs))
 end
 
 function Box(expr::HomExpr{:generator})
@@ -115,6 +117,8 @@ end
   create(A::Ports) = WiringDiagram(munit(Ports), A)
 end
 
+munit(::Type{Ports{Value}}) where Value = Ports(Value[])
+
 # Unbiased variants of braiding (permutation), copying, and merging.
 
 function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
@@ -154,7 +158,7 @@ end
 function dunit(A::Ports)
   f = WiringDiagram(munit(Ports), otimes(A,A))
   n = length(A)
-  for (i, value) in enumerate(A.ports)
+  for (i, value) in enumerate(A)
     v = add_box!(f, Junction(value, 0, 2))
     add_wires!(f, ((v,1) => (output_id(f),i), (v,2) => (output_id(f),i+n)))
   end
@@ -164,7 +168,7 @@ end
 function dcounit(A::Ports)
   f = WiringDiagram(otimes(A,A), munit(Ports))
   n = length(A)
-  for (i, value) in enumerate(A.ports)
+  for (i, value) in enumerate(A)
     v = add_box!(f, Junction(value, 2, 0))
     add_wires!(f, ((input_id(f),i) => (v,1), (input_id(f),i+n) => (v,2)))
   end

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -29,7 +29,6 @@ import ..WiringDiagramCore: Box, WiringDiagram, Ports,
 function Box(expr::HomExpr{:generator})
   Box(first(expr), collect_values(dom(expr)), collect_values(codom(expr)))
 end
-add_box!(f::WiringDiagram, expr::HomExpr) = add_box!(f, Box(expr))
 
 function WiringDiagram(inputs::ObExpr, outputs::ObExpr)
   WiringDiagram(Ports(inputs), Ports(outputs))

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -6,7 +6,7 @@ types and functions to represent diagonals, codiagonals, units, and counits in
 wiring diagrams as special *junction nodes*.
 """
 module AlgebraicWiringDiagrams
-export dom, codom, id, compose, ⋅, ∘, otimes, ⊗, munit, braid, permute,
+export Ports, dom, codom, id, compose, ⋅, ∘, otimes, ⊗, munit, braid, permute,
   mcopy, delete, Δ, ◇, mmerge, create, ∇, □, dunit, dcounit, ocompose,
   Junction, add_junctions, add_junctions!, rem_junctions, merge_junctions
 
@@ -18,13 +18,29 @@ import ...Doctrines: ObExpr, HomExpr, MonoidalCategoryWithBidiagonals,
   dom, codom, id, compose, ⋅, ∘, otimes, ⊗, munit, braid,
   mcopy, delete, Δ, ◇, mmerge, create, ∇, □, dunit, dcounit
 using ..WiringDiagramCore, ..WiringLayers
-import ..WiringDiagramCore: Box, WiringDiagram, Ports,
-  input_ports, output_ports, add_box!
+import ..WiringDiagramCore: Box, WiringDiagram, input_ports, output_ports
 
 # Categorical interface
 #######################
 
+""" A list of ports.
+
+The objects in categories of wiring diagrams.
+"""
+@auto_hash_equals struct Ports{Value}
+  ports::Vector{Value}
+end
+Base.eachindex(A::Ports) = eachindex(A.ports)
+Base.length(A::Ports) = length(A.ports)
+
 # Constructors.
+
+function WiringDiagram(value::Any, inputs::Ports, outputs::Ports)
+  WiringDiagram(value, inputs.ports, outputs.ports)
+end
+function WiringDiagram(inputs::Ports, outputs::Ports)
+  WiringDiagram(inputs.ports, outputs.ports)
+end
 
 function Box(expr::HomExpr{:generator})
   Box(first(expr), collect_values(dom(expr)), collect_values(codom(expr)))

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -1,4 +1,4 @@
-""" Generic data structure for wiring diagrams (aka, string diagrams).
+""" Generic data structures for wiring diagrams (aka, string diagrams).
 
 A (directed) wiring diagram consists of a collection of boxes with input and
 output ports connected by wires. A box can be atomic (possessing no internal
@@ -16,14 +16,14 @@ representation that can be serialized to and from GraphML or translated into
 Graphviz or other declarative diagram languages.
 """
 module WiringDiagramCore
-export AbstractBox, Box, WiringDiagram, Wire, Ports, Port, PortKind,
-  InputPort, OutputPort, input_ports, output_ports, port_value,
-  input_id, output_id, outer_ids, boxes, box_ids, nboxes, nwires, box, wires,
-  has_wire, graph, add_box!, add_boxes!, add_wire!, add_wires!, rem_box!,
-  rem_boxes!, rem_wire!, rem_wires!, validate_ports,
+export AbstractBox, Box, WiringDiagram, Wire, Port, PortKind,
+  InputPort, OutputPort, input_ports, output_ports, input_id, output_id,
+  outer_ids, boxes, box_ids, nboxes, nwires, box, wires, has_wire, graph,
+  add_box!, add_boxes!, add_wire!, add_wires!, rem_box!, rem_boxes!, rem_wire!,
+  rem_wires!, port_value, validate_ports, is_permuted_equal,
   all_neighbors, neighbors, outneighbors, inneighbors, in_wires, out_wires,
   singleton_diagram, induced_subdiagram, encapsulated_subdiagram,
-  substitute, encapsulate, is_permuted_equal
+  substitute, encapsulate
 
 using Compat
 using AutoHashEquals
@@ -122,14 +122,6 @@ function from_wire_data(wire::WireData, edge::Edge)
        from_port_data(wire.target, dst(edge)))
 end
 
-""" List of ports: object in the category of wiring diagrams.
-"""
-@auto_hash_equals struct Ports{Value}
-  ports::Vector{Value}
-end
-Base.eachindex(A::Ports) = eachindex(A.ports)
-Base.length(A::Ports) = length(A.ports)
-
 """ Base type for any box (node) in a wiring diagram.
 
 This type represents an arbitrary black box with inputs and outputs.
@@ -164,7 +156,7 @@ function Base.show(io::IO, box::Box)
   print(io, "])")
 end
 
-""" Wiring diagram: morphism in the category of wiring diagrams.
+""" A directed wiring diagram, aka a string diagram.
 
 The wiring diagram is implemented using the following internal data structures.
 A LightGraphs `DiGraph` stores the "skeleton" of the diagram: a simple directed
@@ -198,12 +190,6 @@ end
 
 function WiringDiagram(input_ports::Vector, output_ports::Vector)
   WiringDiagram(nothing, input_ports, output_ports)
-end
-function WiringDiagram(value::Any, inputs::Ports, outputs::Ports)
-  WiringDiagram(value, inputs.ports, outputs.ports)
-end
-function WiringDiagram(inputs::Ports, outputs::Ports)
-  WiringDiagram(inputs.ports, outputs.ports)
 end
 
 input_id(::WiringDiagram) = 1

--- a/src/wiring_diagrams/Core.jl
+++ b/src/wiring_diagrams/Core.jl
@@ -16,8 +16,8 @@ representation that can be serialized to and from GraphML or translated into
 Graphviz or other declarative diagram languages.
 """
 module WiringDiagramCore
-export AbstractBox, Box, WiringDiagram, Wire, Ports, PortValueError, Port,
-  PortKind, InputPort, OutputPort, input_ports, output_ports, port_value,
+export AbstractBox, Box, WiringDiagram, Wire, Ports, Port, PortKind,
+  InputPort, OutputPort, input_ports, output_ports, port_value,
   input_id, output_id, outer_ids, boxes, box_ids, nboxes, nwires, box, wires,
   has_wire, graph, add_box!, add_boxes!, add_wire!, add_wires!, rem_box!,
   rem_boxes!, rem_wire!, rem_wires!, validate_ports,
@@ -129,16 +129,6 @@ end
 end
 Base.eachindex(A::Ports) = eachindex(A.ports)
 Base.length(A::Ports) = length(A.ports)
-
-""" Error thrown when the source and target ports of a wire are incompatible.
-"""
-struct PortValueError <: Exception
-  source_port::Any
-  target_port::Any
-end
-function Base.showerror(io::IO, exc::PortValueError)
-  print(io, `Ports $(exc.source_port) and $(exc.target_port) are incompatible`)
-end
 
 """ Base type for any box (node) in a wiring diagram.
 
@@ -408,8 +398,7 @@ end
 
 """ Check compatibility of source and target ports.
 
-Throws a `PortValueError` when the ports are incompatible. The default
-implementation of this method is a no-op.
+The default implementation is a no-op.
 """
 function validate_ports(source_port, target_port) end
 

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -15,8 +15,8 @@ export to_hom_expr, to_wiring_diagram
 using Compat
 using LightGraphs
 
-using ...Syntax
-using ...Doctrines: id, compose, otimes, munit, mcopy, mmerge, create, delete
+using ...Syntax, ...Doctrines
+using ...Syntax: syntax_module
 using ...Doctrines.Permutations
 using ..WiringDiagramCore, ..WiringLayers, ..AlgebraicWiringDiagrams
 import ..WiringLayers: to_wiring_diagram
@@ -26,16 +26,19 @@ using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 #######################
 
 """ Convert a morphism expression into a wiring diagram.
-
-The morphism expression should belong to the doctrine of symmetric monoidal
-categories, possibly with diagonals and codiagonals. Thus, the doctrines of
-cartesian, cocartesian, and biproduct categories are supported.
 """
 function to_wiring_diagram(expr::GATExpr)
+  signature = syntax_module(expr).signature()
+  to_wiring_diagram(signature.Hom, expr)
+end
+function to_wiring_diagram(T::Type, expr::GATExpr)
   functor((Ports, WiringDiagram), expr;
     terms = Dict(
-      :Ob => expr -> Ports([first(expr)]),
-      :Hom => expr -> singleton_diagram(Box(expr)),
+      :Ob => expr -> Ports{T}([first(expr)]),
+      :Hom => expr -> singleton_diagram(T,
+        Box(first(expr),
+            to_wiring_diagram(T, dom(expr)),
+            to_wiring_diagram(T, codom(expr))))
     )
   )
 end

--- a/src/wiring_diagrams/Serialization.jl
+++ b/src/wiring_diagrams/Serialization.jl
@@ -60,7 +60,7 @@ convert_from_graph_data(::Type{T}, data::AbstractDict) where T <: AbstractDict =
 
 function convert_from_graph_data(Value::Type, data::AbstractDict)
   @assert length(data) == 1
-  first(values(data))::Value
+  convert(Value, first(values(data)))
 end
 function convert_from_graph_data(::Type{Symbol}, data::AbstractDict)
   @assert length(data) == 1

--- a/test/graphics/GraphvizWiringDiagrams.jl
+++ b/test/graphics/GraphvizWiringDiagrams.jl
@@ -2,8 +2,7 @@ module TestGraphvizWiringDiagrams
 
 using Test
 
-using Catlab.Doctrines, Catlab.WiringDiagrams
-using Catlab.Graphics
+using Catlab.WiringDiagrams, Catlab.Graphics
 import Catlab.Graphics: Graphviz
 
 function stmts(graph::Graphviz.Graph, type::Type)
@@ -14,10 +13,8 @@ function stmts(graph::Graphviz.Graph, type::Type, attr::Symbol)
     if stmt isa type && haskey(stmt.attrs, attr) ]
 end
 
-A, B = Ob(FreeBiproductCategory, :A, :B)
-I = munit(FreeBiproductCategory.Ob)
-f = to_wiring_diagram(Hom(:f, A, B))
-g = to_wiring_diagram(Hom(:g, B, A))
+f = singleton_diagram(Box(:f, [:A], [:B]))
+g = singleton_diagram(Box(:g, [:B], [:A]))
 
 # Simple wiring diagrams, with default settings.
 graph = to_graphviz(f)
@@ -28,11 +25,11 @@ graph = to_graphviz(f)
 @test stmts(graph, Graphviz.Edge, :xlabel) == []
 @test length(stmts(graph, Graphviz.Subgraph)) == 2
 
-graph = to_graphviz(to_wiring_diagram(Hom(:h, I, A)))
+graph = to_graphviz(singleton_diagram(Box(:h, Symbol[], [:A])))
 @test stmts(graph, Graphviz.Node, :comment) == ["h"]
 @test length(stmts(graph, Graphviz.Subgraph)) == 1
 
-graph = to_graphviz(to_wiring_diagram(Hom(:h, I, I)))
+graph = to_graphviz(singleton_diagram(Box(:h, Symbol[], Symbol[])))
 @test stmts(graph, Graphviz.Node, :comment) == ["h"]
 @test length(stmts(graph, Graphviz.Subgraph)) == 0
 
@@ -46,7 +43,7 @@ for orientation in instances(LayoutOrientation)
 end
 
 # Junction nodes.
-graph = to_graphviz(add_junctions!(compose(f, mcopy(Ports(B)))))
+graph = to_graphviz(add_junctions!(compose(f, mcopy(Ports([:B])))))
 @test stmts(graph, Graphviz.Node, :comment) == ["f","junction"]
 
 # Edge labels.

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -1,7 +1,8 @@
 module TestAlgebraicWiringDiagrams
 using Test
 
-using Catlab.Doctrines, Catlab.WiringDiagrams
+using Catlab.Doctrines: Ob, Hom, FreeSymmetricMonoidalCategory
+using Catlab.WiringDiagrams
 
 # Categorical interface
 #######################

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -1,7 +1,6 @@
 module TestAlgebraicWiringDiagrams
 using Test
 
-using Catlab.Doctrines: Ob, Hom, FreeSymmetricMonoidalCategory
 using Catlab.WiringDiagrams
 
 # Categorical interface
@@ -11,16 +10,16 @@ using Catlab.WiringDiagrams
 #---------
 
 # Generators
-A, B = Ob(FreeSymmetricMonoidalCategory, :A, :B)
-f = singleton_diagram(Box(Hom(:f,A,B)))
-g = singleton_diagram(Box(Hom(:g,B,A)))
+A, B = Ports([:A]), Ports([:B])
+f = singleton_diagram(Box(:f,A,B))
+g = singleton_diagram(Box(:g,B,A))
 @test nboxes(f) == 1
-@test boxes(f) == [ Box(Hom(:f,A,B)) ]
+@test boxes(f) == [ Box(:f,A,B) ]
 @test nwires(f) == 2
 
 # Composition
 @test nboxes(compose(f,g)) == 2
-@test boxes(compose(f,g)) == [ Box(Hom(:f,A,B)), Box(Hom(:g,B,A)) ]
+@test boxes(compose(f,g)) == [ Box(:f,A,B), Box(:g,B,A) ]
 @test nwires(compose(f,g)) == 3
 
 # Domains and codomains
@@ -118,7 +117,7 @@ X = Ports([:A])
 ####################
 
 f, g, h = map([:f, :g, :h]) do sym
-  (i::Int) -> singleton_diagram(Box(Hom(Symbol("$sym$i"), A, A)))
+  (i::Int) -> singleton_diagram(Box(Symbol("$sym$i"), A, A))
 end
 
 # Identity

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -1,7 +1,7 @@
 module TestAlgebraicWiringDiagrams
 using Test
 
-using Catlab.WiringDiagrams
+using Catlab.Doctrines, Catlab.WiringDiagrams
 
 # Categorical interface
 #######################
@@ -83,15 +83,22 @@ add_wires!(d, [
 @test codom(mcopy(Ports([:A,:B]),3)) == Ports([:A,:B,:A,:B,:A,:B])
 
 # Associativity
-X = Ports([:A])
-@test compose(mcopy(X), otimes(id(X),mcopy(X))) == mcopy(X,3)
-@test compose(mcopy(X), otimes(mcopy(X),id(X))) == mcopy(X,3)
+A = Ports([:A])
+@test compose(mcopy(A), otimes(id(A),mcopy(A))) == mcopy(A,3)
+@test compose(mcopy(A), otimes(mcopy(A),id(A))) == mcopy(A,3)
 
 # Commutativity
-@test compose(mcopy(X), braid(X,X)) == mcopy(X)
+@test compose(mcopy(A), braid(A,A)) == mcopy(A)
 
-# Unit
-@test compose(mcopy(X), otimes(id(X),delete(X))) == id(X)
+# Unitality
+@test compose(mcopy(A), otimes(id(A),delete(A))) == id(A)
+
+# Instances
+A = Ports{CartesianCategory.Hom}([:A])
+@test mcopy(A) == mcopy(Ports([:A]))
+@test delete(A) == delete(Ports([:A]))
+@test_throws MethodError mmerge(A)
+@test_throws MethodError create(A)
 
 # Codiagonals
 #------------
@@ -103,21 +110,28 @@ X = Ports([:A])
 @test codom(mmerge(Ports([:A,:B]),3)) == Ports([:A,:B])
 
 # Associativity
-X = Ports([:A])
-@test compose(otimes(id(X),mmerge(X)), mmerge(X)) == mmerge(X,3)
-@test compose(otimes(mmerge(X),id(X)), mmerge(X)) == mmerge(X,3)
+A = Ports([:A])
+@test compose(otimes(id(A),mmerge(A)), mmerge(A)) == mmerge(A,3)
+@test compose(otimes(mmerge(A),id(A)), mmerge(A)) == mmerge(A,3)
 
 # Commutativity
-@test compose(braid(X,X), mmerge(X)) == mmerge(X)
+@test compose(braid(A,A), mmerge(A)) == mmerge(A)
 
-# Unit
-@test compose(otimes(id(X),create(X)), mmerge(X)) == id(X)
+# Unitality
+@test compose(otimes(id(A),create(A)), mmerge(A)) == id(A)
+
+# Instances
+A = Ports{CocartesianCategory.Hom}([:A])
+@test mmerge(A) == mmerge(Ports([:A]))
+@test create(A) == create(Ports([:A]))
+@test_throws MethodError mcopy(A)
+@test_throws MethodError delete(A)
 
 # Operadic interface
 ####################
 
 f, g, h = map([:f, :g, :h]) do sym
-  (i::Int) -> singleton_diagram(Box(Symbol("$sym$i"), A, A))
+  (i::Int) -> singleton_diagram(Box(Symbol("$sym$i"), [:A], [:A]))
 end
 
 # Identity

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -93,7 +93,7 @@ A = Ports([:A])
 # Unitality
 @test compose(mcopy(A), otimes(id(A),delete(A))) == id(A)
 
-# Instances
+# Cartesian categories
 A = Ports{CartesianCategory.Hom}([:A])
 @test mcopy(A) == mcopy(Ports([:A]))
 @test delete(A) == delete(Ports([:A]))
@@ -120,12 +120,28 @@ A = Ports([:A])
 # Unitality
 @test compose(otimes(id(A),create(A)), mmerge(A)) == id(A)
 
-# Instances
+# Cocartesian categories
 A = Ports{CocartesianCategory.Hom}([:A])
 @test mmerge(A) == mmerge(Ports([:A]))
 @test create(A) == create(Ports([:A]))
 @test_throws MethodError mcopy(A)
 @test_throws MethodError delete(A)
+
+# Bidiagonals
+#------------
+
+# Monoidal categories with bidiagonals, and non-naturality of explicit
+# representation.
+A = Ports{MonoidalCategoryWithBidiagonals.Hom}([:A])
+@test boxes(mcopy(A)) == [ Junction(:A,1,2) ]
+@test boxes(mcopy(otimes(A,A))) == repeat([ Junction(:A,1,2) ], 2)
+@test compose(create(A), mcopy(A)) != create(otimes(A,A))
+@test compose(mmerge(A), delete(A)) != delete(otimes(A,A))
+
+# Biproduct categories, and naturality of implicit representation.
+A = Ports{BiproductCategory.Hom}([:A])
+@test compose(create(A), mcopy(A)) == create(otimes(A,A))
+@test compose(mmerge(A), delete(A)) == delete(otimes(A,A))
 
 # Operadic interface
 ####################
@@ -161,53 +177,51 @@ d = compose(f(1),f(2))
 # Junctions
 ###########
 
+# Add and remove junctions
+#-------------------------
+
 A, B, C = [ Ports([sym]) for sym in [:A, :B, :C] ]
 f = singleton_diagram(Box(:f, [:A], [:B]))
 g = singleton_diagram(Box(:g, [:B], [:C]))
 
-junction_diagram(args...) = singleton_diagram(Junction(args...))
-
-# Add and remove junctions
-#-------------------------
-
 # Copies.
 d = compose(f, mcopy(B))
-junctioned = compose(f, junction_diagram(:B,1,2))
+junctioned = compose(f, junction_diagram(B,1,2))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
 d = compose(mcopy(A), otimes(f,f))
-junctioned = compose(junction_diagram(:A,1,2), otimes(f,f))
+junctioned = compose(junction_diagram(A,1,2), otimes(f,f))
 @test is_permuted_equal(add_junctions(d), junctioned, [3,1,2])
 @test rem_junctions(junctioned) == d
 
 # Merges.
 d = compose(mmerge(A), f)
-junctioned = compose(junction_diagram(:A,2,1), f)
+junctioned = compose(junction_diagram(A,2,1), f)
 @test is_permuted_equal(add_junctions(d), junctioned, [2,1])
 @test rem_junctions(junctioned) == d
 
 d = compose(otimes(f,f), mmerge(B))
-junctioned = compose(otimes(f,f), junction_diagram(:B,2,1))
+junctioned = compose(otimes(f,f), junction_diagram(B,2,1))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
 # Deletions.
 d = compose(f, delete(B))
-junctioned = compose(f, junction_diagram(:B,1,0))
+junctioned = compose(f, junction_diagram(B,1,0))
 @test add_junctions(d) == junctioned
 @test rem_junctions(junctioned) == d
 
 # Creations.
 d = compose(create(A), f)
-junctioned = compose(junction_diagram(:A,0,1), f)
+junctioned = compose(junction_diagram(A,0,1), f)
 @test is_permuted_equal(add_junctions(d), junctioned, [2,1])
 @test rem_junctions(junctioned) == d
 
 # Copies, merges, deletions, and creations, all at once.
 d = compose(create(A), f, mcopy(B), mmerge(B), g, delete(C))
-junctioned = compose(junction_diagram(:A,0,1), f, junction_diagram(:B,1,2),
-                     junction_diagram(:B,2,1), g, junction_diagram(:C,1,0))
+junctioned = compose(junction_diagram(A,0,1), f, junction_diagram(B,1,2),
+                     junction_diagram(B,2,1), g, junction_diagram(C,1,0))
 actual = add_junctions(d)
 # XXX: An isomorphism test would be more convenient.
 perm = [ findfirst([b] .== boxes(actual)) for b in boxes(junctioned) ]
@@ -217,21 +231,22 @@ perm = [ findfirst([b] .== boxes(actual)) for b in boxes(junctioned) ]
 # Simplify junctions
 #-------------------
 
+A = Ports([:A])
 j = junction_diagram
 
 # Comonoid laws.
-@test merge_junctions(j(:A,1,2)⋅(j(:A,1,2)⊗id(A))) ==
-  j(:A,1,3)⋅permute(A⊗A⊗A,[3,1,2]) # FIXME: Shouldn't need permutation.
-@test merge_junctions(j(:A,1,2)⋅(id(A)⊗j(:A,1,2))) == j(:A,1,3)
-@test merge_junctions(j(:A,1,2)⋅(j(:A,1,0)⊗id(A))) == j(:A,1,1)
-@test merge_junctions(j(:A,1,2)⋅(id(A)⊗j(:A,1,0))) == j(:A,1,1)
+@test merge_junctions(j(A,1,2)⋅(j(A,1,2)⊗id(A))) ==
+  j(A,1,3)⋅permute(A⊗A⊗A,[3,1,2]) # FIXME: Shouldn't need permutation.
+@test merge_junctions(j(A,1,2)⋅(id(A)⊗j(A,1,2))) == j(A,1,3)
+@test merge_junctions(j(A,1,2)⋅(j(A,1,0)⊗id(A))) == j(A,1,1)
+@test merge_junctions(j(A,1,2)⋅(id(A)⊗j(A,1,0))) == j(A,1,1)
 
 # Caps and cups.
-@test merge_junctions(j(:A,0,1)⋅j(:A,1,2)) == j(:A,0,2)
-@test merge_junctions(j(:A,2,1)⋅j(:A,1,0)) == j(:A,2,0)
+@test merge_junctions(j(A,0,1)⋅j(A,1,2)) == j(A,0,2)
+@test merge_junctions(j(A,2,1)⋅j(A,1,0)) == j(A,2,0)
 
 # Zigzag laws.
-@test merge_junctions((id(A)⊗j(:A,0,2))⋅(j(:A,2,0)⊗id(A))) == j(:A,1,1)
-@test merge_junctions((j(:A,0,2)⊗id(A))⋅(id(A)⊗j(:A,2,0))) == j(:A,1,1)
+@test merge_junctions((id(A)⊗j(A,0,2))⋅(j(A,2,0)⊗id(A))) == j(A,1,1)
+@test merge_junctions((j(A,0,2)⊗id(A))⋅(id(A)⊗j(A,2,0))) == j(A,1,1)
 
 end

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -1,75 +1,73 @@
 module TestWiringDiagramAlgorithms
 
 using Test
-using Catlab.Doctrines, Catlab.WiringDiagrams
+using Catlab.WiringDiagrams
+
+A, B, C, D = [ Ports([sym]) for sym in [:A, :B, :C, :D] ]
+I = munit(Ports)
+f = singleton_diagram(Box(:f, [:A], [:B]))
+g = singleton_diagram(Box(:g, [:B], [:C]))
+h = singleton_diagram(Box(:h, [:C], [:D]))
 
 # Normalization
 ###############
 
-A, B, C, D = Ob(FreeCartesianCategory, :A, :B, :C, :D)
-I = munit(FreeCartesianCategory.Ob)
-f = Hom(:f, A, B)
-g = Hom(:g, B, C)
-h = Hom(:h, C, D)
-
 # Normalize copies.
-d = to_wiring_diagram(compose(mcopy(A), otimes(f,f)))
-normalized = to_wiring_diagram(compose(f, mcopy(B)))
+d = compose(mcopy(A), otimes(f,f))
+normalized = compose(f, mcopy(B))
 @test normalize_copy!(d) == normalized
 
-d = to_wiring_diagram(compose(f, mcopy(B), otimes(g,g)))
+d = compose(f, mcopy(B), otimes(g,g))
 normalize_copy!(d)
-normalized = to_wiring_diagram(compose(f, g, mcopy(C)))
+normalized = compose(f, g, mcopy(C))
 perm = sortperm(boxes(d); by=box->box.value)
 @test is_permuted_equal(d, normalized, perm)
 
-d = to_wiring_diagram(compose(mcopy(A), otimes(f,f), otimes(g,g)))
+d = compose(mcopy(A), otimes(f,f), otimes(g,g))
 normalize_copy!(d)
 perm = sortperm(boxes(d); by=box->box.value)
 @test is_permuted_equal(d, normalized, perm)
 
 # Normalize deletions.
-d = to_wiring_diagram(f)
-@test normalize_delete!(d) == to_wiring_diagram(f)
+@test normalize_delete!(copy(f)) == f
 
 d = WiringDiagram(I,I)
-add_box!(d, Box(f))
+add_box!(d, first(boxes(f)))
 @test normalize_delete!(d) == WiringDiagram(I,I)
 
 d = WiringDiagram(A, B)
-fv = add_box!(d, Box(f))
-gv = add_box!(d, Box(g))
-hv = add_box!(d, Box(h))
+fv = add_box!(d, first(boxes(f)))
+gv = add_box!(d, first(boxes(g)))
+hv = add_box!(d, first(boxes(h)))
 add_wires!(d, [
   (input_id(d),1) => (fv,1),
   (fv,1) => (gv,1),
   (gv,1) => (hv,1),
   (fv,1) => (output_id(d),1),
 ])
-@test normalize_delete!(d) == to_wiring_diagram(f)
+@test normalize_delete!(d) == f
 
 # Normalize wiring diagrams representing morphisms in a cartesian category.
-d = to_wiring_diagram(compose(
+d = compose(
   mcopy(A),
   otimes(id(A),mcopy(A)),
   otimes(f,f,f),
   otimes(id(B), id(B), compose(g, delete(C)))
-))
-normalized = to_wiring_diagram(compose(f, mcopy(B)))
+)
+normalized = compose(f, mcopy(B))
 @test normalize_cartesian!(d) == normalized
 
 # Layout
 ########
 
-d = to_wiring_diagram(f)
-@test crossing_minimization_by_sort(d, box_ids(d), sources=[input_id(d)]) == [1]
+@test crossing_minimization_by_sort(f, box_ids(f), sources=[input_id(d)]) == [1]
 
-d = to_wiring_diagram(otimes(f,g))
+d = otimes(f,g)
 @test crossing_minimization_by_sort(d, box_ids(d), sources=[input_id(d)]) == [1,2]
 
 d = WiringDiagram(I,I)
-fv1, fv2 = add_box!(d, Box(f)), add_box!(d, Box(f))
-gv1, gv2 = add_box!(d, Box(g)), add_box!(d, Box(g))
+fv1, fv2 = add_box!(d, first(boxes(f))), add_box!(d, first(boxes(f)))
+gv1, gv2 = add_box!(d, first(boxes(g))), add_box!(d, first(boxes(g)))
 add_wires!(d, [ Wire((fv1,1) => (gv1,1)), Wire((fv2,1),(gv2,1)) ])
 @test crossing_minimization_by_sort(d, [gv1,gv2], sources=[fv1,fv2]) == [1,2]
 @test crossing_minimization_by_sort(d, [fv1,fv2], targets=[gv1,gv2]) == [1,2]

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -33,13 +33,13 @@ d = to_wiring_diagram(f)
 @test normalize_delete!(d) == to_wiring_diagram(f)
 
 d = WiringDiagram(I,I)
-add_box!(d, f)
+add_box!(d, Box(f))
 @test normalize_delete!(d) == WiringDiagram(I,I)
 
 d = WiringDiagram(A, B)
-fv = add_box!(d, f)
-gv = add_box!(d, g)
-hv = add_box!(d, h)
+fv = add_box!(d, Box(f))
+gv = add_box!(d, Box(g))
+hv = add_box!(d, Box(h))
 add_wires!(d, [
   (input_id(d),1) => (fv,1),
   (fv,1) => (gv,1),
@@ -68,8 +68,8 @@ d = to_wiring_diagram(otimes(f,g))
 @test crossing_minimization_by_sort(d, box_ids(d), sources=[input_id(d)]) == [1,2]
 
 d = WiringDiagram(I,I)
-fv1, fv2 = add_box!(d, f), add_box!(d, f)
-gv1, gv2 = add_box!(d, g), add_box!(d, g)
+fv1, fv2 = add_box!(d, Box(f)), add_box!(d, Box(f))
+gv1, gv2 = add_box!(d, Box(g)), add_box!(d, Box(g))
 add_wires!(d, [ Wire((fv1,1) => (gv1,1)), Wire((fv2,1),(gv2,1)) ])
 @test crossing_minimization_by_sort(d, [gv1,gv2], sources=[fv1,fv2]) == [1,2]
 @test crossing_minimization_by_sort(d, [fv1,fv2], targets=[gv1,gv2]) == [1,2]

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -11,10 +11,10 @@ function validate_ports(source_port::Symbol, target_port::Symbol)
   end
 end
 
-A, B, C, D = [ Ports([sym]) for sym in [:A, :B, :C, :D] ]
-f = Box(:f, [:A], [:B])
-g = Box(:g, [:B], [:C])
-h = Box(:h, [:C], [:D])
+A, B, C, D = [:A], [:B], [:C], [:D]
+f = Box(:f, A, B)
+g = Box(:g, B, C)
+h = Box(:h, C, D)
 
 # Imperative interface
 ######################
@@ -47,10 +47,10 @@ d = WiringDiagram(A, C)
 fv = add_box!(d, f)
 gv = add_box!(d, g)
 
-@test input_ports(d, fv) == [:A]
-@test output_ports(d, fv) == [:B]
-@test input_ports(d, output_id(d)) == [:C]
-@test output_ports(d, input_id(d)) == [:A]
+@test input_ports(d, fv) == A
+@test output_ports(d, fv) == B
+@test input_ports(d, output_id(d)) == C
+@test output_ports(d, input_id(d)) == A
 @test_throws ErrorException input_ports(d, input_id(d))
 @test_throws ErrorException output_ports(d, output_id(d))
 
@@ -183,7 +183,7 @@ box_map = Dict(box(sub,v).value => v for v in box_ids(sub))
 ]))
 
 d = encapsulate(d0, [fv,gv], discard_boxes=true, value=:e)
-@test boxes(d) == [ Box(:e, [:A], [:C]), h ]
+@test boxes(d) == [ Box(:e, A, C), h ]
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
 @test Set(wires(d)) == Set(map(Wire, [
   (input_id(d),1) => (box_map[:e],1),

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -1,13 +1,13 @@
 module TestWiringDiagramCore
 using Test
 
-using Catlab.WiringDiagrams
+using Catlab.WiringDiagrams.WiringDiagramCore
 import Catlab.WiringDiagrams.WiringDiagramCore: validate_ports
 
 # For testing purposes, check equality of port symbols.
 function validate_ports(source_port::Symbol, target_port::Symbol)
   if source_port != target_port
-    throw(PortValueError(source_port, target_port))
+    error("Source port $source_port does not equal target port $target_port")
   end
 end
 
@@ -69,7 +69,7 @@ add_wire!(d, (gv,1) => (output_id(d),1))
 @test nwires(d) == 3
 @test has_wire(d, fv, gv)
 @test has_wire(d, (fv,1) => (gv,1))
-@test_throws PortValueError add_wire!(d, (gv,1) => (fv,1))
+@test_throws ErrorException add_wire!(d, (gv,1) => (fv,1))
 @test wires(d) == map(Wire, [
   (input_id(d),1) => (fv,1),
   (fv,1) => (gv,1),

--- a/test/wiring_diagrams/Core.jl
+++ b/test/wiring_diagrams/Core.jl
@@ -144,7 +144,7 @@ add_wires!(d0, Pair[
 @test boxes(sub) == [ g, h ]
 d = substitute(d0, subv)
 @test nboxes(d) == 3
-@test Set(boxes(d)) == Set([ f, g, h ])
+@test boxes(d) == [f, g, h]
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
 @test nwires(d) == 4
 @test Set(wires(d)) == Set(map(Wire, [
@@ -174,7 +174,7 @@ d = encapsulate(d0, [fv,gv])
 @test nwires(d) == 3
 sub = first(b for b in boxes(d) if isa(b, WiringDiagram))
 @test nboxes(sub) == 2
-@test Set(boxes(sub)) == Set([ f, g ])
+@test boxes(sub) == [f, g]
 box_map = Dict(box(sub,v).value => v for v in box_ids(sub))
 @test Set(wires(sub)) == Set(map(Wire, [
   (input_id(sub),1) => (box_map[:f],1),
@@ -183,7 +183,7 @@ box_map = Dict(box(sub,v).value => v for v in box_ids(sub))
 ]))
 
 d = encapsulate(d0, [fv,gv], discard_boxes=true, value=:e)
-@test Set(boxes(d)) == Set([ Box(:e, [:A], [:C]), h ])
+@test boxes(d) == [ Box(:e, [:A], [:C]), h ]
 box_map = Dict(box(d,v).value => v for v in box_ids(d))
 @test Set(wires(d)) == Set(map(Wire, [
   (input_id(d),1) => (box_map[:e],1),

--- a/test/wiring_diagrams/Expressions.jl
+++ b/test/wiring_diagrams/Expressions.jl
@@ -14,8 +14,7 @@ A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
 f, g = Hom(:f,A,B), Hom(:g,B,C)
 
 # Functorality of conversion.
-fd, gd = singleton_diagram(Box(f)), singleton_diagram(Box(g))
-@test to_wiring_diagram(f) == fd
+fd, gd = to_wiring_diagram(f), to_wiring_diagram(g)
 @test to_wiring_diagram(compose(f,g)) == compose(fd,gd)
 @test to_wiring_diagram(otimes(f,g)) == otimes(fd,gd)
 @test to_wiring_diagram(munit(FreeSymmetricMonoidalCategory.Ob)) == munit(Ports)

--- a/test/wiring_diagrams/Expressions.jl
+++ b/test/wiring_diagrams/Expressions.jl
@@ -4,6 +4,7 @@ using Test
 using LightGraphs
 
 using Catlab.Doctrines, Catlab.WiringDiagrams
+using Catlab.Syntax: syntax_module
 using Catlab.WiringDiagrams.WiringDiagramExpressions: find_parallel,
   find_series, transitive_reduction!
 
@@ -23,15 +24,15 @@ fd, gd = to_wiring_diagram(f), to_wiring_diagram(g)
 #######################
 
 function roundtrip(f::HomExpr)
-  to_hom_expr(FreeBiproductCategory, to_wiring_diagram(f))
+  to_hom_expr(syntax_module(f), to_wiring_diagram(f))
 end
 
-A, B, C, D = Ob(FreeBiproductCategory, :A, :B, :C, :D)
-I = munit(FreeBiproductCategory.Ob)
-f, g, h, k = Hom(:f,A,B), Hom(:g,B,C), Hom(:h,C,D), Hom(:k,D,C)
+# Symmetric monoidal category
+#----------------------------
 
-# Monoidal category
-#------------------
+A, B, C, D = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C, :D)
+I = munit(FreeSymmetricMonoidalCategory.Ob)
+f, g, h, k = Hom(:f,A,B), Hom(:g,B,C), Hom(:h,C,D), Hom(:k,D,C)
 
 # Base case.
 @test roundtrip(f) == f
@@ -106,15 +107,15 @@ expr = compose(otimes(m,id(B)), otimes(id(B),b,id(B)), otimes(id(B),n))
 @test roundtrip(Hom(:m,A,I)⋅Hom(:n,I,B)) == Hom(:m,A,I)⊗Hom(:n,I,B)
 @test roundtrip(Hom(:m,I,I)⊗Hom(:n,I,I)) == Hom(:m,I,I)⊗Hom(:n,I,I)
 
-# Symmetric monoidal category
-#----------------------------
-
 # Braidings.
 @test roundtrip(braid(A,B)) == braid(A,B)
 @test roundtrip(otimes(id(A),braid(B,C))) == otimes(id(A),braid(B,C))
 
 # Diagonals and codiagonals
 #--------------------------
+
+A, B, C, D = Ob(FreeBiproductCategory, :A, :B, :C, :D)
+f, g = Hom(:f,A,B), Hom(:g,B,C)
 
 # Diagonals.
 @test roundtrip(mcopy(A)) == mcopy(A)

--- a/test/wiring_diagrams/GraphML.jl
+++ b/test/wiring_diagrams/GraphML.jl
@@ -2,7 +2,6 @@ module TestGraphMLWiringDiagrams
 
 using Test
 using LightXML
-using Catlab.Doctrines
 using Catlab.WiringDiagrams
 
 # Round trip wiring diagrams with dictionary box and wire data.
@@ -31,9 +30,8 @@ function roundtrip_symbolic(f::WiringDiagram)
   parse_graphml(Symbol, Symbol, Nothing, xdoc)
 end
 
-A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
-f = to_wiring_diagram(Hom(:f, A, B))
-g = to_wiring_diagram(Hom(:g, B, C))
+f = singleton_diagram(Box(:f, [:A], [:B]))
+g = singleton_diagram(Box(:g, [:B], [:C]))
 
 @test roundtrip_symbolic(f) == f
 @test roundtrip_symbolic(compose(f,g)) == compose(f,g)
@@ -41,13 +39,10 @@ g = to_wiring_diagram(Hom(:g, B, C))
 
 # Round trip nested, symbolic wiring diagrams.
 
-f = to_wiring_diagram(Hom(:f, A, B))
-diagram = WiringDiagram(:outer, [:A], [:B])
-fv = add_box!(diagram, f)
-add_wires!(diagram, [
-  Wire((input_id(diagram),1) => (fv,1)),
-  Wire((fv,1) => (output_id(diagram),1))
-])
-@test roundtrip_symbolic(diagram) == diagram
+inner = copy(f)
+inner.value = :inner
+outer = singleton_diagram(f)
+outer.value = :outer
+@test roundtrip_symbolic(outer) == outer
 
 end

--- a/test/wiring_diagrams/JSON.jl
+++ b/test/wiring_diagrams/JSON.jl
@@ -2,7 +2,6 @@ module TestJSONWiringDiagrams
 
 using Test
 import JSON
-using Catlab.Doctrines
 using Catlab.WiringDiagrams
 
 # Round trip wiring diagrams with dictionary box and wire data.
@@ -31,9 +30,8 @@ function roundtrip_symbolic(f::WiringDiagram)
   parse_json_graph(Symbol, Symbol, Nothing, JSON.parse(json))
 end
 
-A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
-f = to_wiring_diagram(Hom(:f, A, B))
-g = to_wiring_diagram(Hom(:g, B, C))
+f = singleton_diagram(Box(:f, [:A], [:B]))
+g = singleton_diagram(Box(:g, [:B], [:C]))
 
 @test roundtrip_symbolic(f) == f
 @test roundtrip_symbolic(compose(f,g)) == compose(f,g)
@@ -41,13 +39,10 @@ g = to_wiring_diagram(Hom(:g, B, C))
 
 # Round trip nested, symbolic wiring diagrams.
 
-f = to_wiring_diagram(Hom(:f, A, B))
-diagram = WiringDiagram(:outer, [:A], [:B])
-fv = add_box!(diagram, f)
-add_wires!(diagram, [
-  Wire((input_id(diagram),1) => (fv,1)),
-  Wire((fv,1) => (output_id(diagram),1))
-])
-@test roundtrip_symbolic(diagram) == diagram
+inner = copy(f)
+inner.value = :inner
+outer = singleton_diagram(inner)
+outer.value = :outer
+@test roundtrip_symbolic(outer) == outer
 
 end


### PR DESCRIPTION
Addresses #74. The types `Ports` and `WiringDiagram` now take a type parameter. For example, we would write `WiringDiagram{CartesianCategory.Hom}` for wiring diagrams representing morphisms in a cartesian monoidal category. The type `WiringDiagram{Any}` behaves exactly as before, so there should be few breaking changes.

This PR also takes the opportunity to refactor the unit tests for wiring diagrams, eliminating uses of GAT expressions except where necessary.

Future PRs will improve support for specific doctrines, such as dagger categories, compact closed categories, and bicategories of relations.