### PR TITLE
Wiring diagrams for dagger categories and compact closed categories

### DIFF
--- a/docs/literate/graphics/composejl_wiring_diagrams.jl
+++ b/docs/literate/graphics/composejl_wiring_diagrams.jl
@@ -61,8 +61,7 @@ to_composejl(mcopy(A)⋅(f⊗f)⋅mmerge(B))
 
 # The unit and co-unit of a compact closed category appear as caps and cups.
 
-A, B = Ob(FreeBicategoryRelations, :A, :B)
-f = Hom(:f, A, B)
+A, B = Ob(FreeCompactClosedCategory, :A, :B)
 
 to_composejl(dunit(A))
 #-
@@ -71,6 +70,9 @@ to_composejl(dcounit(A))
 # In a self-dual compact closed category, such as a bicategory of relations,
 # every morphism $f: A \to B$ has a transpose $f^\dagger: B \to A$ given by
 # bending wires:
+
+A, B = Ob(FreeBicategoryRelations, :A, :B)
+f = Hom(:f, A, B)
 
 to_composejl((dunit(A) ⊗ id(B)) ⋅ (id(A) ⊗ f ⊗ id(B)) ⋅ (id(A) ⊗ dcounit(B)))
 

--- a/docs/literate/graphics/tikz_wiring_diagrams.jl
+++ b/docs/literate/graphics/tikz_wiring_diagrams.jl
@@ -65,16 +65,18 @@ to_tikz(mcopy(A)⋅(f⊗f)⋅mmerge(B), labels=true)
 
 # The unit and co-unit of a compact closed category appear as caps and cups.
 
-A, B = Ob(FreeBicategoryRelations, :A, :B)
-f = Hom(:f, A, B)
+A, B = Ob(FreeCompactClosedCategory, :A, :B)
 
-to_tikz(dunit(A))
+to_tikz(dunit(A), arrowtip="Stealth")
 #-
-to_tikz(dcounit(A))
+to_tikz(dcounit(A), arrowtip="Stealth")
 
 # In a self-dual compact closed category, such as a bicategory of relations,
 # every morphism $f: A \to B$ has a transpose $f^\dagger: B \to A$ given by
 # bending wires:
+
+A, B = Ob(FreeBicategoryRelations, :A, :B)
+f = Hom(:f, A, B)
 
 to_tikz((dunit(A) ⊗ id(B)) ⋅ (id(A) ⊗ f ⊗ id(B)) ⋅ (id(A) ⊗ dcounit(B)))
 

--- a/docs/literate/graphics/tikz_wiring_diagrams.jl
+++ b/docs/literate/graphics/tikz_wiring_diagrams.jl
@@ -67,9 +67,9 @@ to_tikz(mcopy(A)⋅(f⊗f)⋅mmerge(B), labels=true)
 
 A, B = Ob(FreeCompactClosedCategory, :A, :B)
 
-to_tikz(dunit(A), arrowtip="Stealth")
+to_tikz(dunit(A), arrowtip="Stealth", labels=true)
 #-
-to_tikz(dcounit(A), arrowtip="Stealth")
+to_tikz(dcounit(A), arrowtip="Stealth", labels=true)
 
 # In a self-dual compact closed category, such as a bicategory of relations,
 # every morphism $f: A \to B$ has a transpose $f^\dagger: B \to A$ given by

--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -535,11 +535,19 @@ end
 
 function show_latex_infix(io::IO, expr::GATExpr, op::String;
                           paren::Bool=false, kw...)
-  show_latex_paren(io, expr) = show_latex(io, expr; paren=true, kw...)
+  show_latex_paren(io, expr) = show_latex(io, expr, paren=true)
   sep = op == " " ? op : " $op "
   if (paren) print(io, "\\left(") end
   join(io, [sprint(show_latex_paren, arg) for arg in args(expr)], sep)
   if (paren) print(io, "\\right)") end
+end
+
+function show_latex_postfix(io::IO, expr::GATExpr, op::String; kw...)
+  @assert length(args(expr)) == 1
+  print(io, "{")
+  show_latex(io, first(expr), paren=true)
+  print(io, "}")
+  print(io, op)
 end
 
 function show_latex_script(io::IO, expr::GATExpr, head::String;

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -330,7 +330,8 @@ end
 end
 
 @syntax FreeCompactClosedCategory(ObExpr,HomExpr) CompactClosedCategory begin
-  dual(A::Ob) = anti_involute(Super.dual(A), dual, otimes, munit)
+  dual(A::Ob) = distribute_unary(involute(Super.dual(A)), dual, otimes,
+                                 unit=munit, contravariant=true)
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
@@ -360,7 +361,13 @@ end
 
 @syntax FreeDaggerCategory(ObExpr,HomExpr) DaggerCategory begin
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
-  dagger(f::Hom) = anti_involute(Super.dagger(f), dagger, compose, id)
+  dagger(f::Hom) = distribute_dagger(involute(Super.dagger(f)))
+end
+
+""" Distribute dagger over composition.
+"""
+function distribute_dagger(f::HomExpr)
+  distribute_unary(f, dagger, compose, unit=id, contravariant=true)
 end
 
 """ Doctrine of *dagger compact category*
@@ -373,14 +380,13 @@ FIXME: This signature should extend both `DaggerCategory` and
 end
 
 @syntax FreeDaggerCompactCategory(ObExpr,HomExpr) DaggerCompactCategory begin
-  dual(A::Ob) = anti_involute(Super.dual(A), dual, otimes, munit)
+  dual(A::Ob) = distribute_unary(involute(Super.dual(A)), dual, otimes,
+                                 unit=munit, contravariant=true)
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
-  function dagger(f::Hom)
-    f = anti_involute(Super.dagger(f), dagger, compose, id)
-    distribute_unary(f, dagger, otimes)
-  end
+  dagger(f::Hom) = distribute_unary(distribute_dagger(involute(Super.dagger(f))),
+                                    dagger, otimes)
 end
 
 function show_latex(io::IO, expr::HomExpr{:dagger}; kw...)

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -8,6 +8,7 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   CartesianClosedCategory, FreeCartesianClosedCategory, hom, ev, curry,
   CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit, mate,
   DaggerCategory, FreeDaggerCategory, dagger,
+  DaggerSymmetricMonoidalCategory, FreeDaggerSymmetricMonoidalCategory,
   DaggerCompactCategory, FreeDaggerCompactCategory
 
 import Base: collect, ndims
@@ -378,6 +379,26 @@ end
 """
 function distribute_dagger(f::HomExpr)
   distribute_unary(f, dagger, compose, unit=id, contravariant=true)
+end
+
+""" Doctrine of *dagger symmetric monoidal category*
+
+Also known as a [symmetric monoidal dagger
+category](https://ncatlab.org/nlab/show/symmetric+monoidal+dagger-category).
+
+FIXME: This signature should extend both `DaggerCategory` and
+`SymmetricMonoidalCategory`, but multiple inheritance is not yet supported.
+"""
+@signature SymmetricMonoidalCategory(Ob,Hom) => DaggerSymmetricMonoidalCategory(Ob,Hom) begin
+  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
+end
+
+@syntax FreeDaggerSymmetricMonoidalCategory(ObExpr,HomExpr) DaggerSymmetricMonoidalCategory begin
+  otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
+  otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
+  compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
+  dagger(f::Hom) = distribute_unary(distribute_dagger(involute(Super.dagger(f))),
+                                    dagger, otimes)
 end
 
 """ Doctrine of *dagger compact category*

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -6,7 +6,7 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   mmerge, create, copair, incl1, incl2, ∇, □,
   MonoidalCategoryWithBidiagonals, BiproductCategory, FreeBiproductCategory,
   CartesianClosedCategory, FreeCartesianClosedCategory, hom, ev, curry,
-  CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit,
+  CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit, mate,
   DaggerCategory, FreeDaggerCategory, dagger,
   DaggerCompactCategory, FreeDaggerCompactCategory
 
@@ -289,8 +289,9 @@ See also `FreeCartesianCategory`.
 end
 
 function show_latex(io::IO, expr::ObExpr{:hom}; kw...)
-  show_latex(io, last(expr))
-  print(io, "^{")
+  print(io, "{")
+  show_latex(io, last(expr), paren=true)
+  print(io, "}^{")
   show_latex(io, first(expr))
   print(io, "}")
 end
@@ -317,13 +318,15 @@ end
   # Counit of duality, aka the evaluation map
   dcounit(A::Ob)::Hom(otimes(A,dual(A)), munit())
   
+  # Adjoint mate of morphism f.
+  mate(f::Hom(A,B))::Hom(dual(B),dual(A)) <= (A::Ob, B::Ob)
+  
   # Closed monoidal category
   hom(A::Ob, B::Ob) = otimes(B, dual(A))
   ev(A::Ob, B::Ob) = otimes(id(B), compose(braid(dual(A),A), dcounit(A)))
   curry(A::Ob, B::Ob, f::Hom) = compose(
     otimes(id(A), compose(dunit(B), braid(dual(B),B))),
-    otimes(f, id(dual(B)))
-  )
+    otimes(f, id(dual(B))))
 end
 
 @syntax FreeCompactClosedCategory(ObExpr,HomExpr) CompactClosedCategory begin
@@ -334,14 +337,16 @@ end
 end
 
 function show_latex(io::IO, expr::ObExpr{:dual}; kw...)
-  show_latex(io, first(expr))
-  print(io, "^*")
+  Syntax.show_latex_postfix(io, expr, "^*")
 end
 function show_latex(io::IO, expr::HomExpr{:dunit}; kw...)
   Syntax.show_latex_script(io, expr, "\\eta")
 end
 function show_latex(io::IO, expr::HomExpr{:dcounit}; kw...)
   Syntax.show_latex_script(io, expr, "\\varepsilon")
+end
+function show_latex(io::IO, expr::HomExpr{:mate}; kw...)
+  Syntax.show_latex_postfix(io, expr, "^*")
 end
 
 # Dagger category
@@ -350,7 +355,7 @@ end
 """ Doctrine of *dagger category*
 """
 @signature Category(Ob,Hom) => DaggerCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob,B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCategory(ObExpr,HomExpr) DaggerCategory begin
@@ -364,7 +369,7 @@ FIXME: This signature should extend both `DaggerCategory` and
 `CompactClosedCategory`, but we don't support multiple inheritance yet.
 """
 @signature CompactClosedCategory(Ob,Hom) => DaggerCompactCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob,B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCompactCategory(ObExpr,HomExpr) DaggerCompactCategory begin
@@ -379,9 +384,5 @@ end
 end
 
 function show_latex(io::IO, expr::HomExpr{:dagger}; kw...)
-  f = first(expr)
-  if (head(f) != :generator) print(io, "\\left(") end
-  show_latex(io, f)
-  if (head(f) != :generator) print(io, "\\right)") end
-  print(io, "^\\dagger")
+  Syntax.show_latex_postfix(io, expr, "^\\dagger")
 end

--- a/src/doctrines/Relations.jl
+++ b/src/doctrines/Relations.jl
@@ -32,12 +32,8 @@ end
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
-
-  function dagger(f::Hom)
-    f = anti_involute(Super.dagger(f), dagger, compose, id)
-    distribute_unary(f, dagger, otimes)
-  end
-  
+  dagger(f::Hom) = distribute_unary(distribute_dagger(involute(Super.dagger(f))),
+                                    dagger, otimes)
   meet(f::Hom, g::Hom) = compose(mcopy(dom(f)), otimes(f,g), mmerge(codom(f)))
   top(A::Ob, B::Ob) = compose(delete(A), create(B))
 end
@@ -63,12 +59,8 @@ end
   otimes(A::Ob, B::Ob) = associate_unit(Super.otimes(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(Super.otimes(f,g))
   compose(f::Hom, g::Hom) = associate(Super.compose(f,g; strict=true))
-  
-  function dagger(f::Hom)
-    f = anti_involute(Super.dagger(f), dagger, compose, id)
-    distribute_unary(f, dagger, otimes)
-  end
-  
+  dagger(f::Hom) = distribute_unary(distribute_dagger(involute(Super.dagger(f))),
+                                    dagger, otimes)
   meet(f::Hom, g::Hom) = compose(mcopy(dom(f)), otimes(f,g), mmerge(codom(f)))
   top(A::Ob, B::Ob) = compose(delete(A), create(B))
 end

--- a/src/graphics/ComposeWiringDiagrams.jl
+++ b/src/graphics/ComposeWiringDiagrams.jl
@@ -10,9 +10,9 @@ const C = Compose
 
 using ...WiringDiagrams
 using ..WiringDiagramLayouts
-using ..WiringDiagramLayouts: AbstractVector2D, Vector2D,
-  BoxShape, RectangleShape, JunctionShape, NoShape,
-  position, size, lower_corner, upper_corner, normal, tangent, wire_points
+using ..WiringDiagramLayouts: AbstractVector2D, Vector2D, BoxShape,
+  RectangleShape, JunctionShape, NoShape, box_label, position, size,
+  lower_corner, upper_corner, normal, tangent, wire_points
 
 # Data types
 ############
@@ -130,7 +130,7 @@ function render_box(shape::BoxShape, value::Any, opts::ComposeOptions)
   render_box(Val(shape), value, opts)
 end
 function render_box(::Val{RectangleShape}, value::Any, opts::ComposeOptions)
-  labeled_rectangle(string(value), rounded=opts.rounded_boxes,
+  labeled_rectangle(box_label(value), rounded=opts.rounded_boxes,
     rect_props=opts.box_props, text_props=opts.text_props)
 end
 function render_box(::Val{JunctionShape}, ::Any, opts::ComposeOptions)

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -8,7 +8,7 @@ using ...WiringDiagrams, ...WiringDiagrams.WiringDiagramSerialization
 import ..Graphviz
 import ..Graphviz: to_graphviz
 using ..WiringDiagramLayouts: LayoutOrientation, LeftToRight, RightToLeft,
-  TopToBottom, BottomToTop, is_horizontal, is_vertical
+  TopToBottom, BottomToTop, is_horizontal, is_vertical, box_label, wire_label
 
 # Constants and data types
 ##########################
@@ -342,13 +342,11 @@ const port_anchors = Dict{Tuple{PortKind,LayoutOrientation},String}(
 
 """ Create a label for the main content of a box.
 """
-node_label(box_value::Any) = string(box_value)
-node_label(::Nothing) = ""
+node_label(box_value) = box_label(box_value)
 
 """ Create a label for an edge.
 """
-edge_label(port_value::Any) = string(port_value)
-edge_label(::Nothing) = ""
+edge_label(port_value) = wire_label(port_value)
 
 """ Encode attributes for Graphviz HTML-like labels.
 """

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -188,9 +188,10 @@ function graphviz_box(junction::Junction, node_id::String;
     width = junction_size,
     height = junction_size,
   )
-  inputs = repeat([Graphviz.NodeID(node_id)], junction.ninputs)
-  outputs = repeat([Graphviz.NodeID(node_id)], junction.noutputs)
-  GraphvizBox([node], inputs, outputs)
+  nin, nout = length(input_ports(junction)), length(output_ports(junction))
+  GraphvizBox([node],
+    repeat([Graphviz.NodeID(node_id)], nin),
+    repeat([Graphviz.NodeID(node_id)], nout))
 end
 
 """ Create "HTML-like" node label for a box.

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -156,13 +156,14 @@ layout_hom_expr(f::HomExpr{:mcopy}, opts) = layout_junction_expr(f, opts)
 layout_hom_expr(f::HomExpr{:delete}, opts) = layout_junction_expr(f, opts)
 layout_hom_expr(f::HomExpr{:mmerge}, opts) = layout_junction_expr(f, opts)
 layout_hom_expr(f::HomExpr{:create}, opts) = layout_junction_expr(f, opts)
-
-layout_port(A::ObExpr{:dual}; kw...) =
-  PortLayout(; value=A, reverse_wires=true, kw...)
 layout_hom_expr(f::HomExpr{:dunit}, opts) =
   layout_junction_expr(f, opts; visible=false, pad=false)
 layout_hom_expr(f::HomExpr{:dcounit}, opts) =
   layout_junction_expr(f, opts; visible=false, pad=false)
+  
+layout_port(A::ObExpr{:dual}; kw...) =
+  PortLayout(; value=A, reverse_wires=true, kw...)
+wire_label(mime::MIME, A::ObExpr{:dual}) = wire_label(mime, first(A))
 
 layout_box_expr(f::HomExpr, opts; kw...) =
   layout_box(f, collect(dom(f)), collect(codom(f)), opts; kw...)
@@ -397,5 +398,27 @@ end
 
 merge_wire_layouts(left::WireLayout, middle::WireLayout, right::WireLayout) =
   vcat(wire_points(left), wire_points(middle), wire_points(right))
+
+# Labels
+########
+
+""" Label for box in wiring diagram.
+"""
+box_label(value) = box_label(MIME("text/plain"), value)
+box_label(mime::MIME, value) = diagram_element_label(mime, value)
+
+""" Label for wire in wiring diagram.
+
+Note: This function takes a port value, not a wire value.
+"""
+wire_label(value) = wire_label(MIME("text/plain"), value)
+wire_label(mime::MIME, value) = diagram_element_label(mime, value)
+
+diagram_element_label(::MIME, value) = string(value)
+diagram_element_label(::MIME, ::Nothing) = ""
+
+function diagram_element_label(::MIME"text/latex", expr::GATExpr)
+  string("\$", sprint(show_latex, expr), "\$")
+end
 
 end

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -288,13 +288,14 @@ end
 """
 function layout_junction(value::Any, inputs::Vector, outputs::Vector,
                          opts::LayoutOptions; visible::Bool=true, pad::Bool=true)
+  nin, nout = length(inputs), length(outputs)
   shape, radius = visible ? (JunctionShape, opts.junction_size) : (NoShape, 0)
   size = 2*SVector(radius, radius)
   box = Box(BoxLayout(value=value, shape=shape, size=size),
             layout_circular_ports(InputPort, inputs, radius, opts;
-                                  pad=pad, label_wires=length(inputs) <= 1),
+                                  pad=pad, label_wires = nin == 1 || nout == 0),
             layout_circular_ports(OutputPort, outputs, radius, opts;
-                                  pad=pad, label_wires=length(outputs) <= 1))
+                                  pad=pad, label_wires = nin == 0 || nout == 1))
   size_to_fit!(singleton_diagram(box), opts)
 end
 

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -9,15 +9,16 @@ module AlgebraicWiringDiagrams
 export Ports, Junction, PortOp, BoxOp,
   functor, dom, codom, id, compose, ⋅, ∘, otimes, ⊗, munit, braid, permute,
   mcopy, delete, Δ, ◇, mmerge, create, ∇, □, dual, dunit, dcounit, mate, dagger,
-  ocompose, junction_diagram, junction_caps, junction_cups, add_junctions,
-  add_junctions!, rem_junctions, merge_junctions
+  meet, top, ocompose, junction_diagram, junction_caps, junction_cups,
+  add_junctions, add_junctions!, rem_junctions, merge_junctions
 
 using AutoHashEquals
 using LightGraphs
 
 using ...GAT, ...Doctrines
 import ...Doctrines: dom, codom, id, compose, ⋅, ∘, otimes, ⊗, munit, braid,
-  mcopy, delete, Δ, ◇, mmerge, create, ∇, □, dual, dunit, dcounit, mate, dagger
+  mcopy, delete, Δ, ◇, mmerge, create, ∇, □, dual, dunit, dcounit, mate, dagger,
+  meet, top
 import ...Syntax: functor
 using ..WiringDiagramCore, ..WiringLayers
 import ..WiringDiagramCore: Box, WiringDiagram, input_ports, output_ports
@@ -268,6 +269,25 @@ dagger(f::WiringDiagram{DaggerCompactCategory.Hom}) =
   functor(f, identity, dagger, contravariant=true)
 mate(f::WiringDiagram{DaggerCompactCategory.Hom}) =
   functor(f, dual, mate, contravariant=true, monoidal_contravariant=true)
+
+# Bicategory of relations
+#------------------------
+
+mcopy(A::Ports{BicategoryRelations.Hom}, n::Int) = junctioned_mcopy(A, n)
+mmerge(A::Ports{BicategoryRelations.Hom}, n::Int) = junctioned_mmerge(A, n)
+delete(A::Ports{BicategoryRelations.Hom}) = junctioned_delete(A)
+create(A::Ports{BicategoryRelations.Hom}) = junctioned_create(A)
+
+dagger(f::WiringDiagram{BicategoryRelations.Hom}) =
+  functor(f, identity, dagger, contravariant=true)
+
+dunit(A::Ports{BicategoryRelations.Hom}) = junction_caps(A)
+dcounit(A::Ports{BicategoryRelations.Hom}) = junction_cups(A)
+
+meet(f::WiringDiagram{BicategoryRelations.Hom}, g::WiringDiagram{BicategoryRelations.Hom}) =
+  compose(mcopy(dom(f)), otimes(f,g), mmerge(codom(f)))
+top(A::Ports{BicategoryRelations.Hom}, B::Ports{BicategoryRelations.Hom}) =
+  compose(delete(A), create(B))
 
 # Operadic interface
 ####################

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -241,11 +241,12 @@ creations, caps, and cups.
 """
 @auto_hash_equals struct Junction{Value} <: AbstractBox
   value::Value
-  ninputs::Int
-  noutputs::Int
+  input_ports::Vector
+  output_ports::Vector
 end
-input_ports(junction::Junction) = repeat([junction.value], junction.ninputs)
-output_ports(junction::Junction) = repeat([junction.value], junction.noutputs)
+
+Junction(value, ninputs::Int, noutputs::Int) =
+  Junction(value, repeat([value], ninputs), repeat([value], noutputs))
 
 """ Wiring diagram with a junction node for each port.
 """
@@ -315,8 +316,9 @@ function rem_junctions(d::WiringDiagram)
   junction_ids = filter(v -> box(d,v) isa Junction, box_ids(d))
   junction_diagrams = map(junction_ids) do v
     junction = box(d,v)::Junction
-    layer = complete_layer(junction.ninputs, junction.noutputs)
-    to_wiring_diagram(layer, input_ports(junction), output_ports(junction))
+    inputs, outputs = input_ports(junction), output_ports(junction)
+    layer = complete_layer(length(inputs), length(outputs))
+    to_wiring_diagram(layer, inputs, outputs)
   end
   substitute(d, junction_ids, junction_diagrams)
 end

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -239,8 +239,8 @@ end
 function junction_to_expr(Ob::Type, junction::Junction)
   ob = coerce_ob(Ob, junction.value)
   compose_simplify_id(
-    mmerge_foldl(ob, junction.ninputs),
-    mcopy_foldl(ob, junction.noutputs)
+    mmerge_foldl(ob, length(input_ports(junction))),
+    mcopy_foldl(ob, length(output_ports(junction)))
   )
 end
 

--- a/test/doctrines/Monoidal.jl
+++ b/test/doctrines/Monoidal.jl
@@ -121,7 +121,9 @@ f = Hom(:f, otimes(A,B), C)
 @test codom(curry(A,B,f)) == hom(B,C)
 
 # Infix notation (LaTeX)
-@test latex(hom(A,B)) == "B^{A}"
+@test latex(hom(A,B)) == "{B}^{A}"
+@test latex(hom(otimes(A,B),C)) == "{C}^{A \\otimes B}"
+@test latex(hom(A,otimes(B,C))) == "{\\left(B \\otimes C\\right)}^{A}"
 @test latex(ev(A,B)) == "\\mathrm{eval}_{A,B}"
 @test latex(curry(A,B,f)) == "\\lambda f"
 
@@ -149,9 +151,10 @@ f = Hom(:f, otimes(A,B), C)
 @test codom(curry(A,B,f)) == hom(B,C)
 
 # Infix notation (LaTeX)
-@test latex(dual(A)) == "A^*"
+@test latex(dual(A)) == "{A}^*"
 @test latex(dunit(A)) == "\\eta_{A}"
 @test latex(dcounit(A)) == "\\varepsilon_{A}"
+@test latex(mate(f)) == "{f}^*"
 
 # Dagger category
 #################
@@ -169,8 +172,8 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 @test dagger(dagger(f)) == f
 
 # Infix notation (LaTeX)
-@test latex(dagger(f)) == "f^\\dagger"
-#@test latex(dagger(compose(f,g))) == "\\left(f \\cdot g\\right)^\\dagger"
+@test latex(dagger(f)) == "{f}^\\dagger"
+#@test latex(dagger(compose(f,g))) == "{\\left(f \\cdot g\\right)}^\\dagger"
 
 # Dagger compact category
 #########################

--- a/test/doctrines/Monoidal.jl
+++ b/test/doctrines/Monoidal.jl
@@ -132,7 +132,7 @@ f = Hom(:f, otimes(A,B), C)
 
 A, B, C = Ob(FreeCompactClosedCategory, :A, :B, :C)
 I = munit(FreeCompactClosedCategory.Ob)
-f = Hom(:f, otimes(A,B), C)
+f, g = Hom(:f, A, B), Hom(:g, B, A)
 
 # Duals
 @test dual(otimes(A,B)) == otimes(dual(B),dual(A))
@@ -140,12 +140,20 @@ f = Hom(:f, otimes(A,B), C)
 @test dual(dual(A)) == A
 @test dual(otimes(dual(A),dual(B))) == otimes(B,A)
 
+# Mates
+@test mate(mate(f)) == f
+@test mate(compose(f,g)) == compose(mate(g),mate(f))
+@test mate(otimes(f,g)) == otimes(mate(g),mate(f))
+
 # Domains and codomains
 @test dom(dunit(A)) == I
 @test codom(dunit(A)) == otimes(dual(A), A)
 @test dom(dcounit(A)) == otimes(A, dual(A))
 @test codom(dcounit(A)) == I
+@test dom(mate(f)) == dual(B)
+@test codom(mate(f)) == dual(A)
 
+f = Hom(:f, otimes(A,B), C)
 @test dom(ev(A,B)) == otimes(hom(A,B),A)
 @test codom(ev(A,B)) == B
 @test dom(curry(A,B,f)) == A

--- a/test/doctrines/Monoidal.jl
+++ b/test/doctrines/Monoidal.jl
@@ -138,6 +138,7 @@ f = Hom(:f, otimes(A,B), C)
 @test dual(otimes(A,B)) == otimes(dual(B),dual(A))
 @test dual(I) == I
 @test dual(dual(A)) == A
+@test dual(otimes(dual(A),dual(B))) == otimes(B,A)
 
 # Domains and codomains
 @test dom(dunit(A)) == I

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -143,6 +143,23 @@ A = Ports{BiproductCategory.Hom}([:A])
 @test compose(create(A), mcopy(A)) == create(otimes(A,A))
 @test compose(mmerge(A), delete(A)) == delete(otimes(A,A))
 
+# Duals
+#------
+
+A, B = [ Ports{CompactClosedCategory.Hom}([sym]) for sym in [:A, :B] ]
+I = munit(typeof(A))
+
+@test boxes(dunit(A)) == [ Junction(:A, [], [DualPort(:A), :A]) ]
+@test boxes(dcounit(A)) == [ Junction(:A, [:A, DualPort(:A)], []) ]
+
+# Domains and codomains
+@test dom(dunit(A)) == I
+@test codom(dunit(A)) == otimes(dual(A),A)
+@test dom(dcounit(A)) == otimes(A,dual(A))
+@test codom(dcounit(A)) == I
+@test codom(dunit(otimes(A,B))) == otimes(dual(B),dual(A),A,B)
+@test dom(dcounit(otimes(A,B))) == otimes(A,B,dual(B),dual(A))
+
 # Operadic interface
 ####################
 

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -203,6 +203,23 @@ g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
 @test mate(mate(compose(f,g))) == compose(f,g)
 @test mate(mate(otimes(f,g))) == otimes(f,g)
 
+# Bicategory of relations
+#------------------------
+
+A, B = [ Ports{BicategoryRelations.Hom}([sym]) for sym in [:A, :B] ]
+R = singleton_diagram(BicategoryRelations.Hom, Box(:R,[:A],[:B]))
+S = singleton_diagram(BicategoryRelations.Hom, Box(:S,[:A],[:B]))
+
+# Domains and codomains
+@test dom(meet(R,S)) == A
+@test codom(meet(R,S)) == B
+@test dom(top(A,B)) == A
+@test codom(top(A,B)) == B
+
+# Units and counits
+@test dunit(A) == merge_junctions(compose(create(A), mcopy(A)))
+@test dcounit(A) == merge_junctions(compose(mmerge(A), delete(A)))
+
 # Operadic interface
 ####################
 

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -149,8 +149,8 @@ A = Ports{BiproductCategory.Hom}([:A])
 A, B = [ Ports{CompactClosedCategory.Hom}([sym]) for sym in [:A, :B] ]
 I = munit(typeof(A))
 
-@test boxes(dunit(A)) == [ Junction(:A, [], [DualPort(:A), :A]) ]
-@test boxes(dcounit(A)) == [ Junction(:A, [:A, DualPort(:A)], []) ]
+@test boxes(dunit(A)) == [ Junction(:A, [], [PortOp{:dual}(:A), :A]) ]
+@test boxes(dcounit(A)) == [ Junction(:A, [:A, PortOp{:dual}(:A)], []) ]
 
 # Domains and codomains
 @test dom(dunit(A)) == I

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -143,8 +143,31 @@ A = Ports{BiproductCategory.Hom}([:A])
 @test compose(create(A), mcopy(A)) == create(otimes(A,A))
 @test compose(mmerge(A), delete(A)) == delete(otimes(A,A))
 
-# Duals
-#------
+# Dagger category
+#----------------
+
+f = singleton_diagram(DaggerSymmetricMonoidalCategory.Hom, Box(:f,[:A],[:B]))
+g = singleton_diagram(DaggerSymmetricMonoidalCategory.Hom, Box(:g,[:B],[:A]))
+
+@test boxes(dagger(f)) == [ BoxOp{:dagger}(Box(:f,[:A],[:B])) ]
+
+# Domain and codomain
+@test dom(dagger(f)) == codom(f)
+@test codom(dagger(f)) == dom(f)
+
+# Functoriality
+@test is_permuted_equal(dagger(compose(f,g)), compose(dagger(g),dagger(f)), [2,1])
+@test dagger(otimes(f,g)) == otimes(dagger(f),dagger(g))
+
+# Involutivity
+@test dagger(dagger(f)) == f
+@test dagger(dagger(compose(f,g))) == compose(f,g)
+@test dagger(dagger(otimes(f,g))) == otimes(f,g)
+
+# Compact closed category
+#------------------------
+
+### Duals
 
 A, B = [ Ports{CompactClosedCategory.Hom}([sym]) for sym in [:A, :B] ]
 I = munit(typeof(A))
@@ -159,6 +182,26 @@ I = munit(typeof(A))
 @test codom(dcounit(A)) == I
 @test codom(dunit(otimes(A,B))) == otimes(dual(B),dual(A),A,B)
 @test dom(dcounit(otimes(A,B))) == otimes(A,B,dual(B),dual(A))
+
+### Adjoint mates
+
+f = singleton_diagram(CompactClosedCategory.Hom, Box(:f,[:A],[:B]))
+g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
+
+@test boxes(mate(f)) == [ BoxOp{:mate}(Box(:f,[:A],[:B])) ]
+
+# Domain and codomain
+@test dom(mate(f)) == dual(codom(f))
+@test codom(mate(f)) == dual(dom(f))
+
+# Functoriality
+@test is_permuted_equal(mate(compose(f,g)), compose(mate(g),mate(f)), [2,1])
+@test is_permuted_equal(mate(otimes(f,g)), otimes(mate(g),mate(f)), [2,1])
+
+# Involutivity
+@test mate(mate(f)) == f
+@test mate(mate(compose(f,g))) == compose(f,g)
+@test mate(mate(otimes(f,g))) == otimes(f,g)
 
 # Operadic interface
 ####################


### PR DESCRIPTION
Sequel to #68. Adds support for wiring diagrams for dagger symmetric monoidal categories, compact closed categories (not necessarily self-dual), dagger compact categories, and bicategories of relations.

Warning: Converting from GAT expressions to these wiring diagrams should work, but going in the other direction does not yet work. This will require a bit more effort.