### PR TITLE
Doctrine and wiring diagrams for traced monoidal categories

### DIFF
--- a/docs/literate/graphics/graphviz_wiring_diagrams.jl
+++ b/docs/literate/graphics/graphviz_wiring_diagrams.jl
@@ -72,6 +72,20 @@ to_graphviz(add_junctions!(to_wiring_diagram(f1)))
 #-
 to_graphviz(add_junctions!(to_wiring_diagram(f2)))
 
+# ### Traced monoidal category
+
+A, B, X, Y = Ob(FreeTracedMonoidalCategory, :A, :B, :X, :Y)
+f = Hom(:f, otimes(X,A), otimes(X,B))
+
+to_graphviz(trace(X, A, B, f))
+#-
+to_graphviz(trace(X, A, B, f), orientation=LeftToRight)
+#-
+g, h = Hom(:g, A, A), Hom(:h, B, B)
+
+trace_naturality = trace(X, A, B, compose(otimes(id(X),g), f, otimes(id(X),h)))
+to_graphviz(trace_naturality, orientation=LeftToRight)
+
 # ## Custom styles
 
 # The visual appearance of wiring diagrams can be customized by setting Graphviz
@@ -80,6 +94,9 @@ to_graphviz(add_junctions!(to_wiring_diagram(f2)))
 # Graphviz documentation. Cell attributes are passed to the primary cell of the
 # [HTML-like label](https://www.graphviz.org/doc/info/shapes.html#html) used for
 # the boxes.
+
+A, B, C = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C)
+f, g = Hom(:f, A, B), Hom(:g, B, C)
 
 to_graphviz(compose(f,g),
   labels = true, label_attr=:headlabel,

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -438,6 +438,8 @@ end
 # Traced monoidal category
 ##########################
 
+""" Doctrine of *traced monoidal category*
+"""
 @signature SymmetricMonoidalCategory(Ob,Hom) => TracedMonoidalCategory(Ob,Hom) begin
   trace(X::Ob, A::Ob, B::Ob, f::Hom(otimes(X,A),otimes(X,B)))::Hom(A,B)
 end

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -9,7 +9,8 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   CompactClosedCategory, FreeCompactClosedCategory, dual, dunit, dcounit, mate,
   DaggerCategory, FreeDaggerCategory, dagger,
   DaggerSymmetricMonoidalCategory, FreeDaggerSymmetricMonoidalCategory,
-  DaggerCompactCategory, FreeDaggerCompactCategory
+  DaggerCompactCategory, FreeDaggerCompactCategory,
+  TracedMonoidalCategory, FreeTracedMonoidalCategory, trace
 
 import Base: collect, ndims
 
@@ -432,4 +433,24 @@ end
 
 function show_latex(io::IO, expr::HomExpr{:dagger}; kw...)
   Syntax.show_latex_postfix(io, expr, "^\\dagger")
+end
+
+# Traced monoidal category
+##########################
+
+@signature SymmetricMonoidalCategory(Ob,Hom) => TracedMonoidalCategory(Ob,Hom) begin
+  trace(X::Ob, A::Ob, B::Ob, f::Hom(otimes(X,A),otimes(X,B)))::Hom(A,B)
+end
+
+@syntax FreeTracedMonoidalCategory(ObExpr,HomExpr) TracedMonoidalCategory begin
+  otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
+  otimes(f::Hom, g::Hom) = associate(new(f,g))
+  compose(f::Hom, g::Hom) = associate(new(f,g; strict=true))
+  # FIXME: `GAT.equations` fails to identify the implicit equation.
+  #trace(X::Ob, A::Ob, B::Ob, f::Hom) = new(X,A,B,f; strict=true)
+end
+
+function show_latex(io::IO, expr::HomExpr{:trace}; kw...)
+  X, A, B, f = args(expr)
+  print(io, "\\operatorname{Tr}_{$A,$B}^{$X} \\left($f\\right)")
 end

--- a/test/doctrines/Monoidal.jl
+++ b/test/doctrines/Monoidal.jl
@@ -83,7 +83,7 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 @test proj1(A,B) == otimes(id(A), delete(B))
 @test proj2(A,B) == otimes(delete(A), id(B))
 
-# Infix notation (LaTeX)
+# LaTeX notation
 @test latex(mcopy(A)) == "\\Delta_{A}"
 @test latex(delete(A)) == "\\lozenge_{A}" 
 
@@ -104,7 +104,7 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 @test incl1(A,B) == otimes(id(A), create(B))
 @test incl2(A,B) == otimes(create(A), id(B))
 
-# Infix notation (LaTeX)
+# LaTeX notation
 @test latex(mmerge(A)) == "\\nabla_{A}"
 @test latex(create(A)) == "\\square_{A}"
 
@@ -120,7 +120,7 @@ f = Hom(:f, otimes(A,B), C)
 @test dom(curry(A,B,f)) == A
 @test codom(curry(A,B,f)) == hom(B,C)
 
-# Infix notation (LaTeX)
+# LaTeX notation
 @test latex(hom(A,B)) == "{B}^{A}"
 @test latex(hom(otimes(A,B),C)) == "{C}^{A \\otimes B}"
 @test latex(hom(A,otimes(B,C))) == "{\\left(B \\otimes C\\right)}^{A}"
@@ -159,7 +159,7 @@ f = Hom(:f, otimes(A,B), C)
 @test dom(curry(A,B,f)) == A
 @test codom(curry(A,B,f)) == hom(B,C)
 
-# Infix notation (LaTeX)
+# LaTeX notation
 @test latex(dual(A)) == "{A}^*"
 @test latex(dunit(A)) == "\\eta_{A}"
 @test latex(dcounit(A)) == "\\varepsilon_{A}"
@@ -180,7 +180,7 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 @test dagger(id(A)) == id(A)
 @test dagger(dagger(f)) == f
 
-# Infix notation (LaTeX)
+# LaTeX notation
 @test latex(dagger(f)) == "{f}^\\dagger"
 #@test latex(dagger(compose(f,g))) == "{\\left(f \\cdot g\\right)}^\\dagger"
 
@@ -197,3 +197,17 @@ f, g = Hom(:f, A, B), Hom(:g, B, A)
 @test dagger(otimes(f,g)) == otimes(dagger(f),dagger(g))
 @test (dagger(otimes(compose(f,g),compose(g,f))) == 
        otimes(compose(dagger(g),dagger(f)),compose(dagger(f),dagger(g))))
+
+# Traced monoidal category
+##########################
+
+A, B, X, Y = Ob(FreeTracedMonoidalCategory, :A, :B, :X, :Y)
+f = Hom(:f, X⊗A, X⊗B)
+
+# Domains and codomains
+@test dom(trace(X, A, B, f)) == A
+@test codom(trace(X, A, B, f)) == B
+#@test_throws SyntaxDomainError trace(X, A, B, Hom(:g, A⊗X, B⊗X))
+
+# LaTeX notation
+@test latex(trace(X, A, B, f)) == "\\operatorname{Tr}_{A,B}^{X} \\left(f\\right)"

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -207,6 +207,34 @@ g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
 @test mate(mate(compose(f,g))) == compose(f,g)
 @test mate(mate(otimes(f,g))) == otimes(f,g)
 
+# Traced monoidal category
+#-------------------------
+
+const TracedMon = TracedMonoidalCategory
+A, B, X, Y = [ Ports{TracedMon.Hom}([sym]) for sym in [:A,:B,:X,:Y] ]
+f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:A], [:X,:B]))
+
+# Domain and codomain
+@test dom(trace(X, A, B, f)) == A
+@test codom(trace(X, A, B, f)) == B
+
+# Naturality
+g = singleton_diagram(TracedMon.Hom, Box(:g, [:A], [:A]))
+h = singleton_diagram(TracedMon.Hom, Box(:h, [:B], [:B]))
+@test trace(X, compose(id(X)⊗g, f, id(X)⊗h)) == compose(g, trace(X,f), h)
+
+# Superposing, aka strength
+g = singleton_diagram(TracedMon.Hom, Box(:g, [:C], [:C]))
+@test trace(X, otimes(f,g)) == otimes(trace(X,f), g)
+
+# Symmetry sliding
+f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:Y,:A], [:Y,:X,:B]))
+@test trace(X⊗Y, compose(f, braid(Y,X)⊗id(B))) ==
+  trace(Y⊗X, compose(braid(Y,X)⊗id(A), f))
+
+# Yanking
+@test trace(X, braid(X,X)) == id(X)
+
 # Bicategory of relations
 #------------------------
 

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -212,6 +212,7 @@ g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
 
 const TracedMon = TracedMonoidalCategory
 A, B, X, Y = [ Ports{TracedMon.Hom}([sym]) for sym in [:A,:B,:X,:Y] ]
+I = munit(typeof(A))
 f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:A], [:X,:B]))
 
 # Domain and codomain
@@ -223,7 +224,7 @@ g = singleton_diagram(TracedMon.Hom, Box(:g, [:A], [:A]))
 h = singleton_diagram(TracedMon.Hom, Box(:h, [:B], [:B]))
 @test trace(X, compose(id(X)⊗g, f, id(X)⊗h)) == compose(g, trace(X,f), h)
 
-# Superposing, aka strength
+# Stength, aka superposing
 g = singleton_diagram(TracedMon.Hom, Box(:g, [:C], [:C]))
 @test trace(X, otimes(f,g)) == otimes(trace(X,f), g)
 
@@ -231,6 +232,12 @@ g = singleton_diagram(TracedMon.Hom, Box(:g, [:C], [:C]))
 f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:Y,:A], [:Y,:X,:B]))
 @test trace(X⊗Y, compose(f, braid(Y,X)⊗id(B))) ==
   trace(Y⊗X, compose(braid(Y,X)⊗id(A), f))
+
+# Vanishing
+f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:Y,:A], [:X,:Y,:B]))
+@test trace(X⊗Y, f) == trace(Y, trace(X, f))
+f = singleton_diagram(TracedMon.Hom, Box(:f, [:A], [:B]))
+@test trace(I, f) == f
 
 # Yanking
 @test trace(X, braid(X,X)) == id(X)


### PR DESCRIPTION
Resolves #95.

One neat feature of the wiring diagram representation is that the [axioms for a traced monoidal category](https://ncatlab.org/nlab/show/traced+monoidal+category) are automatically satisfied, as verified in the unit tests. For a graphical interpretation of the axioms, see Table 3 in [Selinger's 1999 paper](https://pdfs.semanticscholar.org/11bc/3ff959f1b6b473400ff8edc5763cfcef5926.pdf).