### PR TITLE
Updated standard library, tests, and documentation to adopt the new where clause notation

### DIFF
--- a/docs/src/apis/core.md
+++ b/docs/src/apis/core.md
@@ -58,7 +58,7 @@ import Catlab.Doctrines: Ob, Hom, ObExpr, HomExpr, dom, codom, compose, id
   Hom(dom::Ob, codom::Ob)::TYPE
 
   id(A::Ob)::Hom(A,A)
-  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) where (A::Ob, B::Ob, C::Ob)
+  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) ⊣ (A::Ob, B::Ob, C::Ob)
 end
 nothing # hide
 ```
@@ -71,10 +71,11 @@ constructors*, `id` (identity) and `compose` (composition).
 
 Notice how the return types of the term constructors depend on the argument
 values. For example, the term `id(A)` has type `Hom(A,A)`. The term constructor
-`compose` also uses *context variables*, listed to the right of the `where`
-clause. This allows us to write `compose(f,g)`, instead of the more verbose
-`compose(A,B,C,f,g)` (for discussion, see Cartmell, 1986, Sec 10: Informal
-syntax).
+`compose` also uses *context variables*, listed to the right of the `⊣`
+symbol. These context variables can also be defined after the `where` clause,
+but the left hand side must be surrounded by parentheses. This allows us to
+write `compose(f,g)`, instead of the more verbose `compose(A,B,C,f,g)` (for
+discussion, see Cartmell, 1986, Sec 10: Informal syntax).
 
 !!! note
 
@@ -224,7 +225,7 @@ import Catlab.Doctrines: Ob, Hom, ObExpr, HomExpr, SymmetricMonoidalCategory,
   mcopy(A::Ob)::Hom(A,otimes(A,A))
   delete(A::Ob)::Hom(A,munit())
 
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) ⊣ (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
 end

--- a/docs/src/apis/core.md
+++ b/docs/src/apis/core.md
@@ -72,7 +72,7 @@ constructors*, `id` (identity) and `compose` (composition).
 Notice how the return types of the term constructors depend on the argument
 values. For example, the term `id(A)` has type `Hom(A,A)`. The term constructor
 `compose` also uses *context variables*, listed to the right of the `⊣`
-symbol. These context variables can also be defined after the `where` clause,
+symbol. These context variables can also be defined after a `where` clause,
 but the left hand side must be surrounded by parentheses. This allows us to
 write `compose(f,g)`, instead of the more verbose `compose(A,B,C,f,g)` (for
 discussion, see Cartmell, 1986, Sec 10: Informal syntax).

--- a/docs/src/apis/core.md
+++ b/docs/src/apis/core.md
@@ -13,13 +13,13 @@ transformed, usually functorially, into more concrete representations, such as
 
 The basic elements of this system are:
 
-1. **Signatures** of generalized algebraic theories (GATs), defined using the 
+1. **Signatures** of generalized algebraic theories (GATs), defined using the
    [`@signature`](@ref) macro. Categories and other typed (multisorted)
    algebraic structures can be defined as GATs.
-   
+
 2. **Instances**, or concrete implementations, of signatures, asserted using the
    [`@instance`](@ref) macro.
-   
+
 3. **Syntax systems** for signatures, defined using the [`@syntax`](@ref) macro.
    These are type-safe expression trees constructed using ordinary Julia
    functions.
@@ -56,9 +56,9 @@ import Catlab.Doctrines: Ob, Hom, ObExpr, HomExpr, dom, codom, compose, id
 @signature Category(Ob,Hom) begin
   Ob::TYPE
   Hom(dom::Ob, codom::Ob)::TYPE
-  
+
   id(A::Ob)::Hom(A,A)
-  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) <= (A::Ob, B::Ob, C::Ob)
+  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) where (A::Ob, B::Ob, C::Ob)
 end
 nothing # hide
 ```
@@ -71,13 +71,13 @@ constructors*, `id` (identity) and `compose` (composition).
 
 Notice how the return types of the term constructors depend on the argument
 values. For example, the term `id(A)` has type `Hom(A,A)`. The term constructor
-`compose` also uses *context variables*, listed to the right of the `<=` symbol.
-This allows us to write `compose(f,g)`, instead of the more verbose
+`compose` also uses *context variables*, listed to the right of the `where`
+clause. This allows us to write `compose(f,g)`, instead of the more verbose
 `compose(A,B,C,f,g)` (for discussion, see Cartmell, 1986, Sec 10: Informal
 syntax).
 
 !!! note
-    
+
     In general, a GAT consists of a *signature*, defining the types and terms of
     the theory, and a set of *axioms*, the equational laws satisfied by models
     of the theory. The theory of categories, for example, has axioms of
@@ -117,7 +117,7 @@ end
 @instance Category(MatrixDomain, Matrix) begin
   dom(M::Matrix) = MatrixDomain(eltype(M), size(M,1))
   codom(M::Matrix) = MatrixDomain(eltype(M), size(M,2))
-  
+
   id(m::MatrixDomain) = Matrix{m.eltype}(I, m.dim, m.dim)
   compose(M::Matrix, N::Matrix) = M*N
 end
@@ -223,8 +223,8 @@ import Catlab.Doctrines: Ob, Hom, ObExpr, HomExpr, SymmetricMonoidalCategory,
 @signature SymmetricMonoidalCategory(Ob,Hom) => CartesianCategory(Ob,Hom) begin
   mcopy(A::Ob)::Hom(A,otimes(A,A))
   delete(A::Ob)::Hom(A,munit())
-  
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) <= (A::Ob, B::Ob, C::Ob)
+
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
 end

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -174,6 +174,9 @@ function signature_code(main_class, base_mod, base_params)
   fns = interface(class)
   toplevel = [ generate_function(replace_symbols(bindings, f)) for f in fns ]
 
+  # add to toplevel
+  toplevel = [toplevel; [Expr(:(=), Expr(:call, a, Expr(:..., :args)), Expr(:call, signature.aliases[a], Expr(:..., :args))) for a in keys(signature.aliases)]]
+
   # Modules must be at top level:
   # https://github.com/JuliaLang/julia/issues/21009
   Expr(:toplevel, mod, toplevel...)

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -209,7 +209,7 @@ function parse_signature_body(expr::Expr)
   axioms = AxiomConstructor[]
   funs = JuliaFunction[]
   for elem in strip_lines(expr).args
-    elem = replace_symbols(aliases, elem)
+    elem = replace_symbols(aliases, strip_lines(elem))
     head = last(parse_docstring(elem)).head
     if head in (:(::), :call, :comparison, :where)
       cons = parse_constructor(elem)
@@ -227,7 +227,7 @@ function parse_signature_body(expr::Expr)
     elseif head in (:(=), :function)
       push!(funs, parse_function(elem))
     elseif head == :macrocall && elem.args[1] == Symbol("@op")
-      aliases[elem.args[4].value] = elem.args[3]
+      aliases[elem.args[3].value] = elem.args[2]
     else
       throw(ParseError("Ill-formed signature element $elem"))
     end

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -387,7 +387,7 @@ end
 function replace_types(bindings::Dict, sig::Signature)::Signature
   Signature([ replace_types(bindings, t) for t in sig.types ],
             [ replace_types(bindings, t) for t in sig.terms ],
-            sig.axioms) # TODO: Create replace_types for axioms
+            [ replace_types(bindings, t) for t in sig.axioms ])
 end
 function replace_types(bindings::Dict, cons::TypeConstructor)::TypeConstructor
   TypeConstructor(replace_symbols(bindings, cons.name), cons.params,
@@ -397,6 +397,12 @@ function replace_types(bindings::Dict, cons::TermConstructor)::TermConstructor
   TermConstructor(cons.name, cons.params,
                   replace_symbols(bindings, cons.typ),
                   replace_types(bindings, cons.context), cons.doc)
+end
+function replace_types(bindings::Dict, cons::AxiomConstructor)::AxiomConstructor
+  AxiomConstructor(cons.name,
+                   replace_symbols(bindings, cons.left),
+                   replace_symbols(bindings, cons.right),
+                   replace_types(bindings, cons.context), cons.doc)
 end
 function replace_types(bindings::Dict, context::Context)::Context
   GAT.Context(((name => @match expr begin

--- a/src/doctrines/Category.jl
+++ b/src/doctrines/Category.jl
@@ -78,15 +78,15 @@ end
 """
 @signature Category(Ob,Hom) => Category2(Ob,Hom,Hom2) begin
   """ 2-morphism in a 2-category """
-  Hom2(dom::Hom(A,B), codom::Hom(A,B))::TYPE <= (A::Ob, B::Ob)
+  Hom2(dom::Hom(A,B), codom::Hom(A,B))::TYPE where (A::Ob, B::Ob)
 
   # Hom categories: Vertical composition
-  id(f)::Hom2(f,f) <= (A::Ob, B::Ob, f::Hom(A,B))
-  compose(α::Hom2(f,g), β::Hom2(g,h))::Hom2(f,h) <=
+  id(f)::Hom2(f,f) where (A::Ob, B::Ob, f::Hom(A,B))
+  compose(α::Hom2(f,g), β::Hom2(g,h))::Hom2(f,h) where
     (A::Ob, B::Ob, f::Hom(A,B), g::Hom(A,B), h::Hom(A,B))
 
   # Horizontal compostion
-  compose2(α::Hom2(f,g), β::Hom2(h,k))::Hom2(compose(f,h),compose(g,k)) <=
+  compose2(α::Hom2(f,g), β::Hom2(h,k))::Hom2(compose(f,h),compose(g,k)) where
     (A::Ob, B::Ob, C::Ob, f::Hom(A,B), g::Hom(A,B), h::Hom(B,C), k::Hom(B,C))
 
   # Unicode syntax

--- a/src/doctrines/Category.jl
+++ b/src/doctrines/Category.jl
@@ -24,16 +24,16 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
   Hom(dom::Ob,codom::Ob)::TYPE
 
   id(A::Ob)::Hom(A,A)
-  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) where (A::Ob, B::Ob, C::Ob)
+  compose(f::Hom(A,B), g::Hom(B,C))::Hom(A,C) ⊣ (A::Ob, B::Ob, C::Ob)
 
   # Unicode syntax
   ⋅(f::Hom, g::Hom) = compose(f, g)
   ∘(f::Hom, g::Hom) = compose(g, f)
 
   # Equivalency Axioms in a category
-  compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
-  compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
-  compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))
+  compose(compose(f,g),h) == compose(f,compose(g,h)) ⊣ (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
+  compose(f,id(B)) == f ⊣ (A::Ob, B::Ob, f::Hom(A,B))
+  compose(id(A),f) == f ⊣ (A::Ob, B::Ob, f::Hom(A,B))
 end
 
 # Convenience constructors
@@ -78,15 +78,15 @@ end
 """
 @signature Category(Ob,Hom) => Category2(Ob,Hom,Hom2) begin
   """ 2-morphism in a 2-category """
-  Hom2(dom::Hom(A,B), codom::Hom(A,B))::TYPE where (A::Ob, B::Ob)
+  Hom2(dom::Hom(A,B), codom::Hom(A,B))::TYPE ⊣ (A::Ob, B::Ob)
 
   # Hom categories: Vertical composition
-  id(f)::Hom2(f,f) where (A::Ob, B::Ob, f::Hom(A,B))
-  compose(α::Hom2(f,g), β::Hom2(g,h))::Hom2(f,h) where
+  id(f)::Hom2(f,f) ⊣ (A::Ob, B::Ob, f::Hom(A,B))
+  compose(α::Hom2(f,g), β::Hom2(g,h))::Hom2(f,h) ⊣
     (A::Ob, B::Ob, f::Hom(A,B), g::Hom(A,B), h::Hom(A,B))
 
   # Horizontal compostion
-  compose2(α::Hom2(f,g), β::Hom2(h,k))::Hom2(compose(f,h),compose(g,k)) where
+  compose2(α::Hom2(f,g), β::Hom2(h,k))::Hom2(compose(f,h),compose(g,k)) ⊣
     (A::Ob, B::Ob, C::Ob, f::Hom(A,B), g::Hom(A,B), h::Hom(B,C), k::Hom(B,C))
 
   # Unicode syntax

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -25,10 +25,10 @@ signature for weak monoidal categories later.
 """
 @signature Category(Ob,Hom) => MonoidalCategory(Ob,Hom) begin
   otimes(A::Ob, B::Ob)::Ob
-  otimes(f::Hom(A,B), g::Hom(C,D))::Hom(otimes(A,C),otimes(B,D)) <=
+  otimes(f::Hom(A,B), g::Hom(C,D))::Hom(otimes(A,C),otimes(B,D)) where
     (A::Ob, B::Ob, C::Ob, D::Ob)
   munit()::Ob
-  
+
   # Unicode syntax
   ⊗(A::Ob, B::Ob) = otimes(A, B)
   ⊗(f::Hom, g::Hom) = otimes(f, g)
@@ -109,7 +109,7 @@ References:
 @signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithDiagonals(Ob,Hom) begin
   mcopy(A::Ob)::Hom(A,otimes(A,A))
   delete(A::Ob)::Hom(A,munit())
-  
+
   # Unicode syntax
   Δ(A::Ob) = mcopy(A)
   ◇(A::Ob) = delete(A)
@@ -121,7 +121,7 @@ Actually, this is a cartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
 @signature MonoidalCategoryWithDiagonals(Ob,Hom) => CartesianCategory(Ob,Hom) begin
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) <= (A::Ob, B::Ob, C::Ob)
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
 end
@@ -136,7 +136,7 @@ Of course, this convention could be reversed.
   otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(new(f,g))
   compose(f::Hom, g::Hom) = associate(new(f,g; strict=true))
-  
+
   pair(f::Hom, g::Hom) = compose(mcopy(dom(f)), otimes(f,g))
   proj1(A::Ob, B::Ob) = otimes(id(A), delete(B))
   proj2(A::Ob, B::Ob) = otimes(delete(A), id(B))
@@ -175,7 +175,7 @@ Actually, this is a cocartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
 @signature MonoidalCategoryWithCodiagonals(Ob,Hom) => CocartesianCategory(Ob,Hom) begin
-  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) <= (A::Ob, B::Ob, C::Ob)
+  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) where (A::Ob, B::Ob, C::Ob)
   incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
   incl2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
 end
@@ -190,7 +190,7 @@ Of course, this convention could be reversed.
   otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(new(f,g))
   compose(f::Hom, g::Hom) = associate(new(f,g; strict=true))
-  
+
   copair(f::Hom, g::Hom) = compose(otimes(f,g), mmerge(codom(f)))
   incl1(A::Ob, B::Ob) = otimes(id(A), create(B))
   incl2(A::Ob, B::Ob) = otimes(create(A), id(B))
@@ -221,7 +221,7 @@ supported.
   mmerge(A::Ob)::Hom(otimes(A,A),A)
   delete(A::Ob)::Hom(A,munit())
   create(A::Ob)::Hom(munit(),A)
-  
+
   # Unicode syntax
   ∇(A::Ob) = mmerge(A)
   Δ(A::Ob) = mcopy(A)
@@ -238,8 +238,8 @@ FIXME: This signature should extend `MonoidalCategoryWithBidiagonals`,
 yet supported.
 """
 @signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BiproductCategory(Ob,Hom) begin
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) <= (A::Ob, B::Ob, C::Ob)
-  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) <= (A::Ob, B::Ob, C::Ob)
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
+  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) where (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
   incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
@@ -269,12 +269,12 @@ A CCC is a cartesian category with internal homs (aka, exponential objects).
 @signature CartesianCategory(Ob,Hom) => CartesianClosedCategory(Ob,Hom) begin
   # Internal hom of A and B, an object representing Hom(A,B)
   hom(A::Ob, B::Ob)::Ob
-  
+
   # Evaluation map
   ev(A::Ob, B::Ob)::Hom(otimes(hom(A,B),A),B)
-  
+
   # Currying (aka, lambda abstraction)
-  curry(A::Ob, B::Ob, f::Hom(otimes(A,B),C))::Hom(A,hom(B,C)) <= (C::Ob)
+  curry(A::Ob, B::Ob, f::Hom(otimes(A,B),C))::Hom(A,hom(B,C)) where (C::Ob)
 end
 
 """ Syntax for a free cartesian closed category.
@@ -285,7 +285,7 @@ See also `FreeCartesianCategory`.
   otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
   otimes(f::Hom, g::Hom) = associate(new(f,g))
   compose(f::Hom, g::Hom) = associate(new(f,g; strict=true))
-  
+
   pair(f::Hom, g::Hom) = compose(mcopy(dom(f)), otimes(f,g))
   proj1(A::Ob, B::Ob) = otimes(id(A), delete(B))
   proj2(A::Ob, B::Ob) = otimes(delete(A), id(B))
@@ -314,16 +314,16 @@ end
 @signature SymmetricMonoidalCategory(Ob,Hom) => CompactClosedCategory(Ob,Hom) begin
   # Dual A^* of object A
   dual(A::Ob)::Ob
-  
+
   # Unit of duality, aka the coevaluation map
   dunit(A::Ob)::Hom(munit(), otimes(dual(A),A))
-  
+
   # Counit of duality, aka the evaluation map
   dcounit(A::Ob)::Hom(otimes(A,dual(A)), munit())
-  
+
   # Adjoint mate of morphism f.
-  mate(f::Hom(A,B))::Hom(dual(B),dual(A)) <= (A::Ob, B::Ob)
-  
+  mate(f::Hom(A,B))::Hom(dual(B),dual(A)) where (A::Ob, B::Ob)
+
   # Closed monoidal category
   hom(A::Ob, B::Ob) = otimes(B, dual(A))
   ev(A::Ob, B::Ob) = otimes(id(B), compose(braid(dual(A),A), dcounit(A)))
@@ -368,7 +368,7 @@ end
 """ Doctrine of *dagger category*
 """
 @signature Category(Ob,Hom) => DaggerCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCategory(ObExpr,HomExpr) DaggerCategory begin
@@ -391,7 +391,7 @@ FIXME: This signature should extend both `DaggerCategory` and
 `SymmetricMonoidalCategory`, but multiple inheritance is not yet supported.
 """
 @signature SymmetricMonoidalCategory(Ob,Hom) => DaggerSymmetricMonoidalCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerSymmetricMonoidalCategory(ObExpr,HomExpr) DaggerSymmetricMonoidalCategory begin
@@ -417,7 +417,7 @@ FIXME: This signature should extend both `DaggerCategory` and
 `CompactClosedCategory`, but multiple inheritance is not yet supported.
 """
 @signature CompactClosedCategory(Ob,Hom) => DaggerCompactCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCompactCategory(ObExpr,HomExpr) DaggerCompactCategory begin

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -25,7 +25,7 @@ signature for weak monoidal categories later.
 """
 @signature Category(Ob,Hom) => MonoidalCategory(Ob,Hom) begin
   otimes(A::Ob, B::Ob)::Ob
-  otimes(f::Hom(A,B), g::Hom(C,D))::Hom(otimes(A,C),otimes(B,D)) where
+  otimes(f::Hom(A,B), g::Hom(C,D))::Hom(otimes(A,C),otimes(B,D)) ⊣
     (A::Ob, B::Ob, C::Ob, D::Ob)
   munit()::Ob
 
@@ -121,7 +121,7 @@ Actually, this is a cartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
 @signature MonoidalCategoryWithDiagonals(Ob,Hom) => CartesianCategory(Ob,Hom) begin
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) ⊣ (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
 end
@@ -175,7 +175,7 @@ Actually, this is a cocartesian *symmetric monoidal* category but we omit these
 qualifiers for brevity.
 """
 @signature MonoidalCategoryWithCodiagonals(Ob,Hom) => CocartesianCategory(Ob,Hom) begin
-  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) where (A::Ob, B::Ob, C::Ob)
+  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) ⊣ (A::Ob, B::Ob, C::Ob)
   incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
   incl2(A::Ob, B::Ob)::Hom(B,otimes(A,B))
 end
@@ -238,8 +238,8 @@ FIXME: This signature should extend `MonoidalCategoryWithBidiagonals`,
 yet supported.
 """
 @signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BiproductCategory(Ob,Hom) begin
-  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) where (A::Ob, B::Ob, C::Ob)
-  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) where (A::Ob, B::Ob, C::Ob)
+  pair(f::Hom(A,B), g::Hom(A,C))::Hom(A,otimes(B,C)) ⊣ (A::Ob, B::Ob, C::Ob)
+  copair(f::Hom(A,C), g::Hom(B,C))::Hom(otimes(A,B),C) ⊣ (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::Hom(otimes(A,B),A)
   proj2(A::Ob, B::Ob)::Hom(otimes(A,B),B)
   incl1(A::Ob, B::Ob)::Hom(A,otimes(A,B))
@@ -274,7 +274,7 @@ A CCC is a cartesian category with internal homs (aka, exponential objects).
   ev(A::Ob, B::Ob)::Hom(otimes(hom(A,B),A),B)
 
   # Currying (aka, lambda abstraction)
-  curry(A::Ob, B::Ob, f::Hom(otimes(A,B),C))::Hom(A,hom(B,C)) where (C::Ob)
+  curry(A::Ob, B::Ob, f::Hom(otimes(A,B),C))::Hom(A,hom(B,C)) ⊣ (C::Ob)
 end
 
 """ Syntax for a free cartesian closed category.
@@ -322,7 +322,7 @@ end
   dcounit(A::Ob)::Hom(otimes(A,dual(A)), munit())
 
   # Adjoint mate of morphism f.
-  mate(f::Hom(A,B))::Hom(dual(B),dual(A)) where (A::Ob, B::Ob)
+  mate(f::Hom(A,B))::Hom(dual(B),dual(A)) ⊣ (A::Ob, B::Ob)
 
   # Closed monoidal category
   hom(A::Ob, B::Ob) = otimes(B, dual(A))
@@ -368,7 +368,7 @@ end
 """ Doctrine of *dagger category*
 """
 @signature Category(Ob,Hom) => DaggerCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) ⊣ (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCategory(ObExpr,HomExpr) DaggerCategory begin
@@ -391,7 +391,7 @@ FIXME: This signature should extend both `DaggerCategory` and
 `SymmetricMonoidalCategory`, but multiple inheritance is not yet supported.
 """
 @signature SymmetricMonoidalCategory(Ob,Hom) => DaggerSymmetricMonoidalCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) ⊣ (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerSymmetricMonoidalCategory(ObExpr,HomExpr) DaggerSymmetricMonoidalCategory begin
@@ -417,7 +417,7 @@ FIXME: This signature should extend both `DaggerCategory` and
 `CompactClosedCategory`, but multiple inheritance is not yet supported.
 """
 @signature CompactClosedCategory(Ob,Hom) => DaggerCompactCategory(Ob,Hom) begin
-  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob, B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) ⊣ (A::Ob, B::Ob)
 end
 
 @syntax FreeDaggerCompactCategory(ObExpr,HomExpr) DaggerCompactCategory begin

--- a/src/doctrines/Relations.jl
+++ b/src/doctrines/Relations.jl
@@ -19,14 +19,14 @@ References:
 """
 @signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
   # Dagger category.
-  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob,B::Ob)
+  dagger(f::Hom(A,B))::Hom(B,A) ⊣ (A::Ob,B::Ob)
 
   # Self-dual compact closed category.
   dunit(A::Ob)::Hom(munit(), otimes(A,A))
   dcounit(A::Ob)::Hom(otimes(A,A), munit())
 
   # Logical operations.
-  meet(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) where (A::Ob, B::Ob)
+  meet(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) ⊣ (A::Ob, B::Ob)
   top(A::Ob, B::Ob)::Hom(A,B)
 end
 
@@ -57,7 +57,7 @@ References:
   cozero(A::Ob)::Hom(A,munit())
 
   # Logical operations.
-  join(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) where (A::Ob, B::Ob)
+  join(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) ⊣ (A::Ob, B::Ob)
   bottom(A::Ob, B::Ob)::Hom(A,B)
 end
 

--- a/src/doctrines/Relations.jl
+++ b/src/doctrines/Relations.jl
@@ -19,14 +19,14 @@ References:
 """
 @signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
   # Dagger category.
-  dagger(f::Hom(A,B))::Hom(B,A) <= (A::Ob,B::Ob)
-  
+  dagger(f::Hom(A,B))::Hom(B,A) where (A::Ob,B::Ob)
+
   # Self-dual compact closed category.
   dunit(A::Ob)::Hom(munit(), otimes(A,A))
   dcounit(A::Ob)::Hom(otimes(A,A), munit())
-  
+
   # Logical operations.
-  meet(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) <= (A::Ob, B::Ob)
+  meet(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) where (A::Ob, B::Ob)
   top(A::Ob, B::Ob)::Hom(A,B)
 end
 
@@ -55,9 +55,9 @@ References:
   mzero(A::Ob)::Hom(munit(),A)
   coplus(A::Ob)::Hom(A,otimes(A,A))
   cozero(A::Ob)::Hom(A,munit())
-  
+
   # Logical operations.
-  join(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) <= (A::Ob, B::Ob)
+  join(f::Hom(A,B), g::Hom(A,B))::Hom(A,B) where (A::Ob, B::Ob)
   bottom(A::Ob, B::Ob)::Hom(A,B)
 end
 

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -122,7 +122,7 @@ axioms = [
                  :f => :(Hom(A,B)), :g => :(Hom(B,C)), :h => :(Hom(C,D))))),
   GAT.AxiomConstructor(:(==), Meta.parse("compose(f,id(B))"), :f,
     GAT.Context((:A => :Ob, :B => :Ob, :f => :(Hom(A,B))))),
-  GAT.AxiomConstructor(:(==), :f, Meta.parse("compose(id(A),f)"),
+  GAT.AxiomConstructor(:(==), Meta.parse("compose(id(A),f)"), :f,
     GAT.Context((:A => :Ob, :B => :Ob, :f => :(Hom(A,B))))),
 ]
 category_signature = GAT.Signature(types, terms, axioms)

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -101,7 +101,8 @@ target = GAT.AxiomConstructor(:(==), Meta.parse("compose(compose(f,g),Mor(C,D))"
   id(X)::Hom(X,X) where (X::Ob)
   compose(f,g)::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob, f::Hom(X,Y), g::Hom(Y,Z))
 
-  compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
+  compose(compose(f,g),h) == compose(f,compose(g,h)) where (
+    A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
   compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
   compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))
 end
@@ -150,7 +151,8 @@ category_signature = GAT.Signature(types, terms, axioms)
 
   # TODO: Fix abbreviation for axioms
   # compose(f,id(B)) == compose(f,id(B::Ob))
-  compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
+  compose(compose(f,g),h) == compose(f,compose(g,h)) where (
+    A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
   compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
   compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))
 end

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -90,6 +90,10 @@ target = GAT.TermConstructor(:compose, [:f,:g], :(Mor(X,Z)),
 
   id(X)::Hom(X,X) where (X::Ob)
   compose(f,g)::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob, f::Hom(X,Y), g::Hom(Y,Z))
+
+  compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
+  compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
+  compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))
 end
 
 @test isa(Category, Module)
@@ -111,7 +115,17 @@ terms = [
     GAT.Context((:X => :Ob, :Y => :Ob, :Z => :Ob,
                  :f => :(Hom(X,Y)), :g => :(Hom(Y,Z))))),
 ]
-category_signature = GAT.Signature(types, terms)
+axioms = [
+  GAT.AxiomConstructor(:(==), Meta.parse("compose(compose(f,g),h)"),
+    Meta.parse("compose(f,compose(g,h))"),
+    GAT.Context((:A => :Ob, :B => :Ob, :C => :Ob, :D => :Ob,
+                 :f => :(Hom(A,B)), :g => :(Hom(B,C)), :h => :(Hom(C,D))))),
+  GAT.AxiomConstructor(:(==), Meta.parse("compose(f,id(B))"), :f,
+    GAT.Context((:A => :Ob, :B => :Ob, :f => :(Hom(A,B))))),
+  GAT.AxiomConstructor(:(==), :f, Meta.parse("compose(id(A),f)"),
+    GAT.Context((:A => :Ob, :B => :Ob, :f => :(Hom(A,B))))),
+]
+category_signature = GAT.Signature(types, terms, axioms)
 
 @test Category.class().signature == category_signature
 
@@ -123,6 +137,10 @@ category_signature = GAT.Signature(types, terms)
 
   id(X::Ob)::Hom(X,X)
   compose(f::Hom(X,Y),g::Hom(Y,Z))::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob)
+
+  compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
+  compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
+  compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))
 end
 
 @test CategoryAbbrev.class().signature == category_signature
@@ -155,7 +173,9 @@ signature = GAT.Signature(
   [ GAT.TermConstructor(:times, [:x,:y], :M,
       GAT.Context((:x => :M, :y => :M))),
     GAT.TermConstructor(:munit, [], :M, GAT.Context()) ],
+  []
 )
+
 @test MonoidExt.class().signature == signature
 
 # GAT expressions in a signature

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -68,11 +68,21 @@ target = GAT.TypeConstructor(:Mor, [:X,:Y],
 @test GAT.replace_types(bindings, cons) == target
 
 cons = GAT.TermConstructor(:compose, [:f,:g], :(Hom(X,Z)),
-  GAT.Context((:X => :Obj, :Y => :Obj, :Z => :Obj,
+  GAT.Context((:X => :Ob, :Y => :Ob, :Z => :Ob,
                :f => :(Hom(X,Y)), :g => :(Hom(Y,Z)))))
 target = GAT.TermConstructor(:compose, [:f,:g], :(Mor(X,Z)),
   GAT.Context((:X => :Obj, :Y => :Obj, :Z => :Obj,
                :f => :(Mor(X,Y)), :g => :(Mor(Y,Z)))))
+@test GAT.replace_types(bindings, cons) == target
+
+cons = GAT.AxiomConstructor(:(==), Meta.parse("compose(compose(f,g),Hom(C,D))"),
+  Meta.parse("compose(f,compose(g,Hom(C,D)))"),
+  GAT.Context((:A => :Ob, :B => :Ob, :C => :Ob, :D => :Ob,
+               :f => :(Hom(A,B)), :g => :(Hom(B,C)))))
+target = GAT.AxiomConstructor(:(==), Meta.parse("compose(compose(f,g),Mor(C,D))"),
+  Meta.parse("compose(f,compose(g,Mor(C,D)))"),
+  GAT.Context((:A => :Obj, :B => :Obj, :C => :Obj, :D => :Obj,
+               :f => :(Mor(A,B)), :g => :(Mor(B,C)))))
 @test GAT.replace_types(bindings, cons) == target
 
 @test GAT.strip_type(:Ob) == :Ob
@@ -138,6 +148,8 @@ category_signature = GAT.Signature(types, terms, axioms)
   id(X::Ob)::Hom(X,X)
   compose(f::Hom(X,Y),g::Hom(Y,Z))::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob)
 
+  # TODO: Fix abbreviation for axioms
+  # compose(f,id(B)) == compose(f,id(B::Ob))
   compose(compose(f,g),h) == compose(f,compose(g,h)) where (A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
   compose(f,id(B)) == f where (A::Ob, B::Ob, f::Hom(A,B))
   compose(id(A),f) == f where (A::Ob, B::Ob, f::Hom(A,B))

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -154,14 +154,12 @@ category_signature = GAT.Signature(types, terms, axioms, aliases)
   @op Hom :→
 
   id(X::Ob)::Hom(X,X)
-  compose(f::Hom(X,Y),g::Hom(Y,Z))::Hom(X,Z) ⊣ (X::Ob, Y::Ob, Z::Ob)
+  (compose(f::Hom(X,Y),g::Hom(Y,Z))::Hom(X,Z)) where (X::Ob, Y::Ob, Z::Ob)
 
-  # TODO: Fix abbreviation for axioms
-  # compose(f,id(B)) == compose(f,id(B::Ob))
-  compose(compose(f,g),h) == compose(f,compose(g,h)) ⊣ (
+  (compose(compose(f,g),h) == compose(f,compose(g,h))) where (
     A::Ob, B::Ob, C::Ob, D::Ob, f::Hom(A,B), g::Hom(B,C), h::Hom(C,D))
-  compose(f,id(B)) == f ⊣ (A::Ob, B::Ob, f::Hom(A,B))
-  compose(id(A),f) == f ⊣ (A::Ob, B::Ob, f::Hom(A,B))
+  (compose(f,id(B)) == f) where (A::Ob, B::Ob, f::Hom(A,B))
+  (compose(id(A),f) == f) where (A::Ob, B::Ob, f::Hom(A,B))
 end
 
 @test CategoryAbbrev.class().signature == category_signature

--- a/test/core/Syntax.jl
+++ b/test/core/Syntax.jl
@@ -102,10 +102,10 @@ x, y = one(FreeMonoidTwo.Elem), two(FreeMonoidTwo.Elem)
 @signature Category(Ob,Hom) begin
   Ob::TYPE
   Hom(dom::Ob, codom::Ob)::TYPE
-  
+
   id(X::Ob)::Hom(X,X)
-  compose(f::Hom(X,Y), g::Hom(Y,Z))::Hom(X,Z) <= (X::Ob, Y::Ob, Z::Ob)
-  
+  compose(f::Hom(X,Y), g::Hom(Y,Z))::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob)
+
   compose(fs::Vararg{Hom}) = foldl(compose, fs)
 end
 

--- a/test/core/Syntax.jl
+++ b/test/core/Syntax.jl
@@ -104,7 +104,7 @@ x, y = one(FreeMonoidTwo.Elem), two(FreeMonoidTwo.Elem)
   Hom(dom::Ob, codom::Ob)::TYPE
 
   id(X::Ob)::Hom(X,X)
-  compose(f::Hom(X,Y), g::Hom(Y,Z))::Hom(X,Z) where (X::Ob, Y::Ob, Z::Ob)
+  compose(f::Hom(X,Y), g::Hom(Y,Z))::Hom(X,Z) ⊣ (X::Ob, Y::Ob, Z::Ob)
 
   compose(fs::Vararg{Hom}) = foldl(compose, fs)
 end


### PR DESCRIPTION
All tests still pass when running `Pkg.test("Catlab")`