### PR TITLE
Added ability to define operation aliases in block form

### DIFF
--- a/docs/src/apis/core.md
+++ b/docs/src/apis/core.md
@@ -91,7 +91,7 @@ discussion, see Cartmell, 1986, Sec 10: Informal syntax).
 
 Notice the `@op` call where we can create method aliases that can then be used
 throughout the rest of the theory and outside of definition. We can either use
-this block notation, or a single line notation such as `@op compose :·` to
+this block notation, or a single line notation such as `@op (·) := compose` to
 define a single alias. Here we utilize this functionality by replacing the `Hom`
 and `compose` methods with their equivalent unicode characters, `→` and `·`
 respectively. These aliases are also automatically available to definitions that

--- a/docs/src/apis/core.md
+++ b/docs/src/apis/core.md
@@ -56,13 +56,16 @@ import Catlab.Doctrines: Ob, Hom, ObExpr, HomExpr, dom, codom, compose, id
 
 ```@example category
 @theory Category(Ob,Hom) begin
+  @op begin
+    (→) := Hom
+    (·) := compose
+  end
+
   Ob::TYPE
   Hom(dom::Ob, codom::Ob)::TYPE
-  @op Hom :→
 
   id(A::Ob)::(A → A)
   compose(f::(A → B), g::(B → C))::(A → C) ⊣ (A::Ob, B::Ob, C::Ob)
-  @op compose :·
 
   (f ⋅ g) ⋅ h == f ⋅ (g ⋅ h) ⊣ ( A::Ob, B::Ob, C::Ob, D::Ob,
                                 f::(A → B), g::(B → C), h::(C → D))
@@ -86,12 +89,13 @@ but the left hand side must be surrounded by parentheses. This allows us to
 write `compose(f,g)`, instead of the more verbose `compose(A,B,C,f,g)` (for
 discussion, see Cartmell, 1986, Sec 10: Informal syntax).
 
-Notice the `@op` call where we can create method aliases that can
-then be used throughout the rest of the theory and outside of definition.
-Here we utilize this functionality by replacing the `Hom` and `compose` methods
-with their equivalent unicode characters, `→` and `·` respectively. These
-aliases are also automatically available to definitions that inherit a doctrine
-that already has the alias defined.
+Notice the `@op` call where we can create method aliases that can then be used
+throughout the rest of the theory and outside of definition. We can either use
+this block notation, or a single line notation such as `@op compose :·` to
+define a single alias. Here we utilize this functionality by replacing the `Hom`
+and `compose` methods with their equivalent unicode characters, `→` and `·`
+respectively. These aliases are also automatically available to definitions that
+inherit a doctrine that already has the alias defined.
 
 !!! note
 

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -269,8 +269,6 @@ function parse_theory_body(expr::Expr)
         [_,block_expr::Expr] => begin
           merge!(aliases, Dict(map(x -> if x.head == :(:=)
                                           x.args[1] => x.args[2]
-                                        elseif x.head == :call && x.args[1] == :(:)
-                                          x.args[3] => x.args[2]
                                         else
                                           throw(ParseError("Ill-formed alias $x"))
                                         end, strip_lines(block_expr).args)))

--- a/src/doctrines/AdditiveMonoidal.jl
+++ b/src/doctrines/AdditiveMonoidal.jl
@@ -16,7 +16,7 @@ The same as `MonoidalCategory` mathematically but with different notation.
   oplus(A::Ob, B::Ob)::Ob
   oplus(f::Hom(A,B), g::Hom(C,D))::Hom(oplus(A,C),oplus(B,D)) <=
     (A::Ob, B::Ob, C::Ob, D::Ob)
-  @op oplus :⊕
+    @op (⊕) := oplus
   mzero()::Ob
 end
 
@@ -62,7 +62,7 @@ notation.
 """
 @signature AdditiveMonoidalCategory(Ob,Hom) => AdditiveSymmetricMonoidalCategory(Ob,Hom) begin
   braid(A::Ob, B::Ob)::Hom(oplus(A,B),oplus(B,A))
-  @op braid :σ
+  @op (σ) := braid
 end
 
 @syntax FreeAdditiveSymmetricMonoidalCategory(ObExpr,HomExpr) AdditiveSymmetricMonoidalCategory begin
@@ -84,9 +84,9 @@ For references, see `MonoidalCategoryWithDiagonals`.
 """
 @signature AdditiveSymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithCodiagonals(Ob,Hom) begin
   mmerge(A::Ob)::Hom(oplus(A,A),A)
-  @op mmerge :∇
+  @op (∇) := mmerge
   create(A::Ob)::Hom(mzero(),A)
-  @op create :□
+  @op (□) := create
 end
 
 """ Doctrine of *cocartesian category*

--- a/src/doctrines/Category.jl
+++ b/src/doctrines/Category.jl
@@ -18,8 +18,8 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
 """
 @theory Category(Ob,Hom) begin
   @op begin
-    Hom :→
-    compose :⋅
+    (→) := Hom
+    (⋅) := compose
   end
 
   """ Object in a category """

--- a/src/doctrines/Category.jl
+++ b/src/doctrines/Category.jl
@@ -17,16 +17,19 @@ This usage is too entrenched to overturn, inconvenient though it may be.
 We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
 """
 @theory Category(Ob,Hom) begin
+  @op begin
+    Hom :→
+    compose :⋅
+  end
+
   """ Object in a category """
   Ob::TYPE
 
   """ Morphism in a category """
   Hom(dom::Ob,codom::Ob)::TYPE
-  @op Hom :→
 
   id(A::Ob)::(A → A)
   compose(f::(A → B), g::(B → C))::(A → C) ⊣ (A::Ob, B::Ob, C::Ob)
-  @op compose :⋅
 
   ∘(f::Hom, g::Hom) = g ⋅ f
 

--- a/src/doctrines/Category.jl
+++ b/src/doctrines/Category.jl
@@ -82,7 +82,7 @@ end
 @signature Category(Ob,Hom) => Category2(Ob,Hom,Hom2) begin
   """ 2-morphism in a 2-category """
   Hom2(dom::Hom(A,B), codom::Hom(A,B))::TYPE ⊣ (A::Ob, B::Ob)
-  @op Hom2 :⇒
+  @op (⇒) := Hom2
 
   # Hom categories: Vertical composition
   id(f)::(f ⇒ f) ⊣ (A::Ob, B::Ob, f::(A ⇒ B))

--- a/src/doctrines/Monoidal.jl
+++ b/src/doctrines/Monoidal.jl
@@ -24,7 +24,7 @@ theory for weak monoidal categories later.
 """
 @signature Category(Ob,Hom) => MonoidalCategory(Ob,Hom) begin
   otimes(A::Ob, B::Ob)::Ob
-  @op otimes :⊗
+  @op (⊗) := otimes
   otimes(f::(A → B), g::(C → D))::((A ⊗ C) → (B ⊗ D)) ⊣
     (A::Ob, B::Ob, C::Ob, D::Ob)
   munit()::Ob
@@ -75,7 +75,7 @@ The theory (but not the axioms) is the same as a braided monoidal category.
 """
 @signature MonoidalCategory(Ob,Hom) => SymmetricMonoidalCategory(Ob,Hom) begin
   braid(A::Ob, B::Ob)::((A ⊗ B) → (B ⊗ A))
-  @op braid :σ
+  @op (σ) := braid
 end
 
 @syntax FreeSymmetricMonoidalCategory(ObExpr,HomExpr) SymmetricMonoidalCategory begin
@@ -105,9 +105,9 @@ References:
 """
 @signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithDiagonals(Ob,Hom) begin
   mcopy(A::Ob)::(A → (A ⊗ A))
-  @op mcopy :Δ
+  @op (Δ) := mcopy
   delete(A::Ob)::(A → munit())
-  @op delete :◊
+  @op (◊) := delete
 end
 
 """ Doctrine of *cartesian category*
@@ -159,13 +159,13 @@ supported.
 """
 @signature SymmetricMonoidalCategory(Ob,Hom) => MonoidalCategoryWithBidiagonals(Ob,Hom) begin
   mcopy(A::Ob)::(A → (A ⊗ A))
-  @op mcopy :Δ
+  @op (Δ) := mcopy
   mmerge(A::Ob)::((A ⊗ A) → A)
-  @op mmerge :∇
+  @op (∇) := mmerge
   delete(A::Ob)::Hom(A,munit())
-  @op delete :◊
+  @op (◊) := delete
   create(A::Ob)::Hom(munit(),A)
-  @op create :□
+  @op (□) := create
 end
 
 """ Doctrine of *bicategory category*

--- a/src/experimental/Markov.jl
+++ b/src/experimental/Markov.jl
@@ -15,7 +15,7 @@ import ...Doctrines: Ob, Hom, dom, codom, compose, ⋅, ∘, otimes, ⊗, braid,
 """
 @signature MonoidalCategoryWithDiagonals(Ob,Hom) => MarkovCategory(Ob,Hom) begin
   expectation(M::(A → B))::(A → B) <= (A::Ob, B::Ob)
-  @op expectation :𝔼
+  @op (𝔼) := expectation
 end
 
 @syntax FreeMarkovCategory(ObExpr,HomExpr) MarkovCategory begin

--- a/src/linear_algebra/GLA.jl
+++ b/src/linear_algebra/GLA.jl
@@ -30,15 +30,15 @@ Functional fragment of graphical linear algebra.
 @theory AdditiveSymmetricMonoidalCategory(Ob,Hom) => LinearFunctions(Ob,Hom) begin
   # Copying and deleting maps.
   mcopy(A::Ob)::(A → (A ⊕ A))
-  @op mcopy :Δ
+  @op (Δ) := mcopy
   delete(A::Ob)::(A → mzero())
-  @op delete :◊
+  @op (◊) := delete
 
   # Addition and zero maps.
   plus(A::Ob)::((A ⊕ A) → A)
-  @op plus :+
+  @op (+) := plus
   zero(A::Ob)::(mzero() → A)
-  
+
   plus(f::(A → B), g::(A → B))::(A → B) ⊣ (A::Ob, B::Ob)
   adjoint(f::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
 
@@ -91,9 +91,9 @@ bicategory of relations (`AbelianBicategoryRelations`), written additively.
 
   # Merging and creating relations (converses of copying and deleting maps).
   mmerge(A::Ob)::((A ⊕ A) → A)
-  @op mmerge :∇
+  @op (∇) := mmerge
   create(A::Ob)::(mzero() → A)
-  @op create :□
+  @op (□) := create
 
   # Co-addition and co-zero relations (converses of addition and zero maps)
   coplus(A::Ob)::(A → (A ⊕ A))

--- a/src/linear_algebra/StructuredGLA.jl
+++ b/src/linear_algebra/StructuredGLA.jl
@@ -24,7 +24,7 @@ than general dense matrices. Morphisms in this category represent structured mat
 """
 @theory LinearFunctions(Ob,Hom) => StructuredLinearFunctions(Ob, Hom) begin
   munit()::Ob
-  @op munit :ℝ
+  @op (ℝ) := munit
 
   diag(v)::(A→A) ⊣ (A::Ob, v::(ℝ()→A))
   upperdiag(v)::(A⊕ℝ() → A⊕ℝ()) ⊣ (A::Ob, v::(ℝ() → A))

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -171,8 +171,8 @@ category_theory = GAT.Theory(types, terms, axioms, aliases)
 """
 @theory CategoryAbbrev(Ob,Hom) begin
   @op begin
-    Hom :→
-    compose :⋅
+    (→) := Hom
+    (⋅) := compose
   end
 
   Ob::TYPE

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -170,13 +170,16 @@ category_theory = GAT.Theory(types, terms, axioms, aliases)
 """ Equivalent shorthand definition of Category theory
 """
 @theory CategoryAbbrev(Ob,Hom) begin
+  @op begin
+    Hom :→
+    compose :⋅
+  end
+
   Ob::TYPE
   Hom(dom::Ob, codom::Ob)::TYPE
-  @op Hom :→
 
   id(X::Ob)::(X → X)
   (compose(f::(X → Y),g::(Y → Z))::(X → Z)) where (X::Ob, Y::Ob, Z::Ob)
-  @op compose :⋅
 
   (f ⋅ g) ⋅ h == f ⋅ (g ⋅ h) ⊣ ( A::Ob, B::Ob, C::Ob, D::Ob,
                                 f::(A → B), g::(B → C), h::(C → D))

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -101,11 +101,11 @@ target = Dict(:→ => :Mor)
 @test_throws ParseError try @eval @signature Category(Ob,Hom) begin
   Ob::TYPE
   Hom(dom, codom)::TYPE ⊣ (dom::Ob, codom::Ob)
-  @op Hom :→
+  @op (→) := Hom
 
   id(X)::(X → X) ⊣ (X::Ob)
   compose(f,g)::(X → Z) ⊣ (X::Ob, Y::Ob, Z::Ob, f::(X → Y), g::(Y → Z))
-  @op compose :⋅
+  @op (⋅) := compose
 
   (f ⋅ g) ⋅ h == f ⋅ (g ⋅ h) ⊣ ( A::Ob, B::Ob, C::Ob, D::Ob,
                                 f::(A → B), g::(B → C), h::(C → D))
@@ -121,11 +121,11 @@ end
 @theory Category(Ob,Hom) begin
   Ob::TYPE
   Hom(dom, codom)::TYPE ⊣ (dom::Ob, codom::Ob)
-  @op Hom :→
+  @op (→) := Hom
 
   id(X)::(X → X) ⊣ (X::Ob)
   compose(f,g)::(X → Z) ⊣ (X::Ob, Y::Ob, Z::Ob, f::(X → Y), g::(Y → Z))
-  @op compose :⋅
+  @op (⋅) := compose
 
   (f ⋅ g) ⋅ h == f ⋅ (g ⋅ h) ⊣ ( A::Ob, B::Ob, C::Ob, D::Ob,
                                 f::(A → B), g::(B → C), h::(C → D))


### PR DESCRIPTION
Added a second notation for `@op` macro inside of the `@theory`

```
@op begin
  Hom :→
  compose :⋅
end
```

Also updated tests to make sure both notations work, and found a typo/bug in one of the ParseError definitions