### PR TITLE
Ellipse shape for Compose.jl and TikZ wiring diagrams

### DIFF
--- a/src/graphics/ComposeWiringDiagrams.jl
+++ b/src/graphics/ComposeWiringDiagrams.jl
@@ -128,17 +128,21 @@ function render_box(layout::BoxLayout, opts::ComposeOptions)
   render_box(Val(layout.shape), layout, opts)
 end
 function render_box(::Val{:rectangle}, layout::BoxLayout, opts::ComposeOptions)
-  labeled_rectangle(box_label(layout.value), rounded=opts.rounded_boxes,
-    rectangle_props=box_props(layout, opts), text_props=opts.props[:text])
+  form = opts.rounded_boxes ? rounded_rectangle() : C.rectangle()
+  labeled_box(form, layout, opts)
 end
-function render_box(::Val{:circle}, layout::BoxLayout, opts::ComposeOptions)
-  labeled_circle(box_label(layout.value),
-    circle_props=box_props(layout, opts), text_props=opts.props[:text])
-end
-function render_box(::Val{:junction}, layout::BoxLayout, opts::ComposeOptions)
+render_box(::Val{:circle}, layout::BoxLayout, opts::ComposeOptions) =
+  labeled_box(C.circle(), layout, opts)
+render_box(::Val{:ellipse}, layout::BoxLayout, opts::ComposeOptions) =
+  labeled_box(C.ellipse(), layout, opts)
+render_box(::Val{:junction}, layout::BoxLayout, opts::ComposeOptions) =
   C.compose(C.context(), C.circle(), box_props(layout, opts)...)
-end
 render_box(::Val{:invisible}, ::BoxLayout, ::ComposeOptions) = C.context()
+
+function labeled_box(form::C.ComposeNode, layout::BoxLayout, opts::ComposeOptions)
+  labeled_form(form, box_label(layout.value),
+    form_props=box_props(layout, opts), text_props=opts.props[:text])
+end
 
 """ Get Compose.jl properties for box.
 """
@@ -154,26 +158,12 @@ end
 # Compose.jl forms
 ##################
 
-""" Draw a circle with text label in Compose.
+""" Draw a form with centered text label in Compose.
 """
-function labeled_circle(label::String;
-    circle_props::ComposeProperties=[], text_props::ComposeProperties=[])
+function labeled_form(form::C.ComposeNode, label::String; rounded::Bool=true,
+    form_props::ComposeProperties=[], text_props::ComposeProperties=[])
   C.compose(C.context(),
-    (C.context(order=1), C.circle(), circle_props...),
-    (C.context(order=2),
-     C.text(0.5, 0.5, label, C.hcenter, C.vcenter),
-     text_props...),
-  )
-end
-
-""" Draw a rectangle with text label in Compose.
-"""
-function labeled_rectangle(label::String; rounded::Bool=true,
-    rectangle_props::ComposeProperties=[], text_props::ComposeProperties=[])
-  C.compose(C.context(),
-    (C.context(order=1),
-     rounded ? rounded_rectangle() : C.rectangle(),
-     rectangle_props...),
+    (C.context(order=1), form, form_props...),
     (C.context(order=2),
      C.text(0.5, 0.5, label, C.hcenter, C.vcenter),
      text_props...),

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -152,7 +152,7 @@ function tikz_port(diagram::WiringDiagram, port::Port, opts::TikZOptions)
     port_dir = svector(opts, port_sign(diagram, port, opts.orientation), 0)
     e2 = svector(opts, 0, 1)
     (tikz_anchor(port_dir), (e2[1]*x, e2[2]*y))
-  elseif shape in (:circle, :junction)
+  elseif shape in (:circle, :ellipse, :junction)
     (normal_angle, (0,0))
   elseif shape == :invisible
     ("center", (0,0))
@@ -283,6 +283,10 @@ const default_tikz_node_styles = Dict{String,Vector{TikZ.Property}}(
     TikZ.Property("circle"),
     TikZ.Property("draw"), TikZ.Property("solid"),
   ],
+  "elliptical box" => [
+    TikZ.Property("ellipse"),
+    TikZ.Property("draw"), TikZ.Property("solid"),
+  ],
   "triangular box" => [
     TikZ.Property("isosceles triangle"),
     TikZ.Property("isosceles triangle stretches"),
@@ -328,6 +332,7 @@ end
 const tikz_shapes = Dict(
   :rectangle => "box",
   :circle => "circular box",
+  :ellipse => "elliptical box",
   :triangle => "triangular box",
   :junction => "junction",
   :invisible => "invisible",

--- a/src/graphics/TikZWiringDiagrams.jl
+++ b/src/graphics/TikZWiringDiagrams.jl
@@ -148,7 +148,7 @@ function tikz_port(diagram::WiringDiagram, port::Port, opts::TikZOptions)
   
   x, y = tikz_position(position(port_value(diagram, port)))
   normal_angle = tikz_angle(normal(diagram, port))
-  anchor, (x, y) = if shape == :rectangle
+  anchor, (x, y) = if shape in (:rectangle, :triangle)
     port_dir = svector(opts, port_sign(diagram, port, opts.orientation), 0)
     e2 = svector(opts, 0, 1)
     (tikz_anchor(port_dir), (e2[1]*x, e2[2]*y))
@@ -237,10 +237,12 @@ function tikz_styles(opts::TikZOptions)
     for style in sort!(["outer box"; collect(opts.used_node_styles)])
     if haskey(default_tikz_node_styles, style)
   )
-  libraries = String[]
+  libraries = [ "shapes.geometric" ] # FIXME: Should use library only if needed.
   if opts.rounded_boxes
-    if haskey(styles, "box")
-      push!(styles["box"], TikZ.Property("rounded corners"))
+    for style in ("box", "triangular box")
+      if haskey(styles, style)
+        push!(styles[style], TikZ.Property("rounded corners"))
+      end
     end
   end
   
@@ -281,6 +283,12 @@ const default_tikz_node_styles = Dict{String,Vector{TikZ.Property}}(
     TikZ.Property("circle"),
     TikZ.Property("draw"), TikZ.Property("solid"),
   ],
+  "triangular box" => [
+    TikZ.Property("isosceles triangle"),
+    TikZ.Property("isosceles triangle stretches"),
+    TikZ.Property("draw"), TikZ.Property("solid"),
+    TikZ.Property("inner sep", "0"),
+  ],
   "junction" => [
     TikZ.Property("circle"),
     TikZ.Property("draw"), TikZ.Property("fill"),
@@ -320,6 +328,7 @@ end
 const tikz_shapes = Dict(
   :rectangle => "box",
   :circle => "circular box",
+  :triangle => "triangular box",
   :junction => "junction",
   :invisible => "invisible",
 )

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -332,9 +332,9 @@ function layout_box(inputs::Vector, outputs::Vector, opts::LayoutOptions;
 end
 
 function layout_box(::Val{:rectangle}, inputs::Vector, outputs::Vector,
-                    opts::LayoutOptions; kw...)
+                    opts::LayoutOptions; shape::Symbol=:rectangle, kw...)
   size = default_box_size(length(inputs), length(outputs), opts)
-  box = Box(BoxLayout(; shape=:rectangle, size=size, kw...),
+  box = Box(BoxLayout(; shape=shape, size=size, kw...),
             layout_linear_ports(InputPort, inputs, size, opts),
             layout_linear_ports(OutputPort, outputs, size, opts))
   size_to_fit!(singleton_diagram(box), opts)
@@ -348,6 +348,12 @@ function layout_box(::Val{:circle}, inputs::Vector, outputs::Vector,
             layout_circular_ports(InputPort, inputs, radius, opts; pad=pad),
             layout_circular_ports(OutputPort, outputs, radius, opts; pad=pad))
   size_to_fit!(singleton_diagram(box), opts)
+end
+
+function layout_box(::Val{:triangle}, inputs::Vector, outputs::Vector,
+                    opts::LayoutOptions; kw...)
+  @assert length(outputs) <= 1 "Cannot use triangle layout with multiple outputs"
+  layout_box(Val(:rectangle), inputs, outputs, opts; shape=:triangle, kw...)
 end
 
 function layout_box(::Val{:junction}, inputs::Vector, outputs::Vector,


### PR DESCRIPTION
Also, makes a start toward a triangle shape for TikZ diagrams, but there are some issues with triangles, notably that orientation is not yet accounted for and rounded corners don't work well, because TikZ is too dumb to factor the rounding into node anchors.