### PR TITLE
Computing pushouts of spans in FinOrd

### DIFF
--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -1,5 +1,6 @@
 module CategoricalAlgebra
 
+include("ShapeDiagrams.jl")
 include("FinSets.jl")
 include("Permutations.jl")
 

--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -1,5 +1,6 @@
 module CategoricalAlgebra
 
+include("FinSets.jl")
 include("Permutations.jl")
 
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -5,6 +5,7 @@ using AutoHashEquals
 
 using ...GAT
 using ...Theories: Category
+using ..ShapeDiagrams
 import ...Theories: dom, codom, compose, ⋅, ∘, id
 
 """ Finite ordinal (natural number).

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,0 +1,57 @@
+module FinSets
+export FinOrd, FinOrdFunction
+
+using AutoHashEquals
+
+using ...GAT
+using ...Theories: Category
+import ...Theories: dom, codom, compose, ⋅, ∘, id
+
+""" Finite ordinal (natural number).
+
+An object in the category of finite ordinals, which is the skeleton of the
+category of finite sets.
+"""
+@auto_hash_equals struct FinOrd{T<:Integer}
+  n::T
+end
+
+""" Function between sets of form `1:n`.
+
+A morphism in the category of finite ordinals, which is the skeleton of the
+category of finite sets.
+
+TODO: Explain data structures: functions, vectors.
+"""
+@auto_hash_equals struct FinOrdFunction{T<:Integer,F}
+  func::F
+  dom::T
+  codom::T
+end
+
+FinOrdFunction(f::AbstractVector) = FinOrdFunction(f, max(f))
+FinOrdFunction(f::AbstractVector, codom::Integer) =
+  FinOrdFunction(f, length(f), codom)
+
+(f::FinOrdFunction)(i::Integer) = f.func(i)
+(f::FinOrdFunction{T,Vector{T}})(i::Integer) where T = f.func[i]
+
+@instance Category(FinOrd, FinOrdFunction) begin
+  dom(f::FinOrdFunction) = FinOrd(f.dom)
+  codom(f::FinOrdFunction) = FinOrd(f.codom)
+  
+  id(A::FinOrd) = FinOrdFunction(identity, A.n, A.n)
+  
+  function compose(f::FinOrdFunction, g::FinOrdFunction)
+    @assert f.codom == g.dom
+    FinOrdFunction(compose_functions(f.func, g.func), f.dom, g.codom)
+  end
+end
+
+compose_functions(f,g) = g∘f # Julia's built-in composition
+compose_functions(::typeof(identity), g) = g
+compose_functions(f, ::typeof(identity)) = f
+compose_functions(::typeof(identity), ::typeof(identity)) = identity
+compose_functions(f::AbstractVector, g::AbstractVector) = g[f]
+
+end

--- a/src/categorical_algebra/ShapeDiagrams.jl
+++ b/src/categorical_algebra/ShapeDiagrams.jl
@@ -1,0 +1,44 @@
+""" Diagrams of a given shape.
+"""
+module ShapeDiagrams
+export Span, Cospan, left, right, apex, base
+
+using ...Theories: dom, codom
+
+""" Span of morphisms in a category.
+"""
+struct Span{Left,Right}
+  left::Left
+  right::Right
+  
+  function Span(left::Left, right::Right; strict::Bool=true) where {Left,Right}
+    if strict && dom(left) != dom(right)
+      error("Domains of legs in span do not match: $left vs $right")
+    end
+    new{Left,Right}(left, right)
+  end
+end
+
+apex(span::Span) = dom(span.left) # == dom(span.right)
+left(span::Span) = span.left
+right(span::Span) = span.right
+
+""" Cospan of morphisms in a category.
+"""
+struct Cospan{Left,Right}
+  left::Left
+  right::Right
+  
+  function Cospan(left::Left, right::Right; strict::Bool=true) where {Left,Right}
+    if strict && codom(left) != codom(right)
+      error("Codomains of legs in cospan do not match: $left vs $right")
+    end
+    new{Left,Right}(left, right)
+  end
+end
+
+base(cospan::Cospan) = codom(cospan.left) # == codom(cospan.right)
+left(cospan::Cospan) = cospan.left
+right(cospan::Cospan) = cospan.right
+
+end

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -2,6 +2,10 @@ module TestCategoricalAlgebra
 
 using Test
 
+@testset "ShapeDiagrams" begin
+  include("ShapeDiagrams.jl")
+end
+
 @testset "FinSets" begin
   include("FinSets.jl")
 end

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -2,6 +2,10 @@ module TestCategoricalAlgebra
 
 using Test
 
+@testset "FinSets" begin
+  include("FinSets.jl")
+end
+
 @testset "Permutations" begin
   include("Permutations.jl")
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -18,7 +18,14 @@ h = FinOrdFunction([3,1,2], 3)
 @test compose(id(dom(f)),f) == f
 @test compose(f,id(codom(f))) == f
 
-# Pushout.
+# Pushout from the empty set: the degenerate case of the coproduct.
+f, g = FinOrdFunction([], 2), FinOrdFunction([], 3)
+cospan = pushout(Span(f,g))
+@test base(cospan) == FinOrd(5)
+@test left(cospan) == FinOrdFunction([1,2], 5)
+@test right(cospan) == FinOrdFunction([3,4,5], 5)
+
+# Pushout from a singleton set.
 f, g = FinOrdFunction([1], 2), FinOrdFunction([2], 3)
 cospan = pushout(Span(f,g))
 @test base(cospan) == FinOrd(4)
@@ -26,5 +33,14 @@ h, k = left(cospan), right(cospan)
 @test compose(f,h) == compose(g,k)
 @test h == FinOrdFunction([1,2], 4)
 @test k == FinOrdFunction([3,1,4], 4)
+
+# Pushout from a two-element set, with non-injective legs.
+f, g = FinOrdFunction([1,1], 2), FinOrdFunction([1,2], 2)
+cospan = pushout(Span(f,g))
+@test base(cospan) == FinOrd(2)
+h, k = left(cospan), right(cospan)
+@test compose(f,h) == compose(g,k)
+@test h == FinOrdFunction([1,2], 2)
+@test k == FinOrdFunction([1,1], 2)
 
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -1,7 +1,8 @@
 module TestFinSets
 using Test
 
-using Catlab.Theories, Catlab.CategoricalAlgebra.FinSets
+using Catlab.Theories
+using Catlab.CategoricalAlgebra.ShapeDiagrams, Catlab.CategoricalAlgebra.FinSets
 
 f = FinOrdFunction([1,3,4], 5)
 g = FinOrdFunction([1,1,2,2,3], 3)
@@ -16,5 +17,14 @@ h = FinOrdFunction([3,1,2], 3)
 @test compose(compose(f,g),h) == compose(f,compose(g,h))
 @test compose(id(dom(f)),f) == f
 @test compose(f,id(codom(f))) == f
+
+# Pushout.
+f, g = FinOrdFunction([1], 2), FinOrdFunction([2], 3)
+cospan = pushout(Span(f,g))
+@test base(cospan) == FinOrd(4)
+h, k = left(cospan), right(cospan)
+@test compose(f,h) == compose(g,k)
+@test h == FinOrdFunction([1,2], 4)
+@test k == FinOrdFunction([3,1,4], 4)
 
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -1,0 +1,20 @@
+module TestFinSets
+using Test
+
+using Catlab.Theories, Catlab.CategoricalAlgebra.FinSets
+
+f = FinOrdFunction([1,3,4], 5)
+g = FinOrdFunction([1,1,2,2,3], 3)
+h = FinOrdFunction([3,1,2], 3)
+@test [f(1),f(2),f(3)] == [1,3,4]
+
+# Category of finite ordinals
+@test dom(f) == FinOrd(3)
+@test codom(f) == FinOrd(5)
+@test compose(f,g) == FinOrdFunction([1,2,2], 3)
+@test compose(g,h) == FinOrdFunction([3,3,1,1,2], 3)
+@test compose(compose(f,g),h) == compose(f,compose(g,h))
+@test compose(id(dom(f)),f) == f
+@test compose(f,id(codom(f))) == f
+
+end

--- a/test/categorical_algebra/ShapeDiagrams.jl
+++ b/test/categorical_algebra/ShapeDiagrams.jl
@@ -1,0 +1,24 @@
+module TestShapeDiagrams
+using Test
+
+using Catlab.Theories, Catlab.CategoricalAlgebra.ShapeDiagrams
+
+A, B, C = Ob(FreeCategory, :A, :B, :C)
+
+# Spans.
+f, g = Hom(:f, C, A), Hom(:g, C, B)
+span = Span(f,g)
+@test apex(span) == C
+@test left(span) == f
+@test right(span) == g
+f = Hom(:f, A, B)
+@test_throws Exception Span(f,g)
+
+# Cospans.
+f, g = Hom(:f, A, C), Hom(:g, B, C)
+cospan = Cospan(f,g)
+@test base(cospan) == C
+@test left(cospan) == f
+@test right(cospan) == g
+
+end


### PR DESCRIPTION
Also includes a basic implementations of the category FinOrd, the skeleton of FinSet. Inspired by [existing code](https://github.com/jpfairbanks/SemanticModels.jl/blob/f772bef38bb5958ceed8051a07e41e53fece2eb3/src/CategoryTheory.jl) in SemanticModels.jl.